### PR TITLE
fix: ship the ESLint formatter in the npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 *.tsbuildinfo
 .DS_Store
+*.tgz

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "files": [
     "dist",
-    "templates"
+    "formatters"
   ],
   "engines": {
     "node": ">=20.11"

--- a/test/test_package.ts
+++ b/test/test_package.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { access, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+import { formatterPath } from "../src/eslintRunner.ts";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const readPackageJson = async (): Promise<{ files?: string[]; bin?: Record<string, string> }> => {
+  const parsed: unknown = JSON.parse(await readFile(path.join(repoRoot, "package.json"), "utf8"));
+  assert.ok(typeof parsed === "object" && parsed !== null);
+  return parsed;
+};
+
+const exists = async (target: string): Promise<boolean> => {
+  try {
+    await access(target);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+describe("published package", () => {
+  it("ships the ESLint formatter", async () => {
+    // `files` originally listed a `templates` directory that does not exist and omitted
+    // `formatters`, so the tarball would have shipped without the formatter every command depends
+    // on — working perfectly from a clone and broken for everyone installing from npm.
+    const { files } = await readPackageJson();
+    assert.ok(files?.includes("formatters"), `files was ${JSON.stringify(files)}`);
+  });
+
+  it("lists nothing in files that is missing from disk", async () => {
+    const { files } = await readPackageJson();
+    for (const entry of files ?? []) {
+      assert.ok(await exists(path.join(repoRoot, entry)), `files lists a missing entry: ${entry}`);
+    }
+  });
+
+  it("resolves the formatter to a file that is really there", async () => {
+    assert.ok(await exists(formatterPath()), `${formatterPath()} does not exist`);
+  });
+
+  it("points bin at the built entry point", async () => {
+    const { bin } = await readPackageJson();
+    assert.equal(bin?.["ever-better"], "dist/cli.js");
+  });
+});


### PR DESCRIPTION
## Summary

`package.json` `files` listed a `templates` directory that has never existed, and omitted
`formatters`. The tarball would therefore have been published **without** `formatters/rule-counts.js`
— the ESLint formatter that `runRuleCounts` resolves relative to the package root.

Every command works from a clone, and `diagnose` / `bootstrap` would have worked from npm too.
`freeze`, `check`, `prune` and `status` — everything that counts violations — would have failed for
every installed user with "eslint produced no output".

Caught by `npm pack --dry-run` before publishing, not by any test.

## Items to Confirm / Review

- **The tarball was verified by installing it, not by reading the file list.** `npm pack`, then
  `npm install ./ever-better-0.1.0.tgz` into a scratch project, then ran the installed
  `./node_modules/.bin/ever-better` against the Vue fixture — `diagnose` and `check` both correct.
- Three new tests guard the class of bug: the formatter is in `files`, nothing in `files` is
  missing from disk, and `formatterPath()` resolves to a file that exists. The second one is what
  would have caught the phantom `templates` entry.
- `*.tgz` added to `.gitignore`.

## Why no test caught it

A test running from the repo sees `formatters/` on disk regardless of what `files` says. Only the
packed artifact differs. The new tests approximate it by checking the manifest against the
filesystem; the real check remains `npm pack --dry-run` before a release, which is now worth
writing into the release procedure.

## Gate

`format`, `lint`, `typecheck`, `build`, 102 `node:test` cases — all green.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)