### PR TITLE
chore: remove the dead exports knip found

### DIFF
--- a/src/detect/framework.ts
+++ b/src/detect/framework.ts
@@ -35,14 +35,6 @@ export const detectRuntime = (framework: Framework, packageJson: PackageJson | n
   return "vite" in deps || "webpack" in deps ? "both" : "node";
 };
 
-/** Extra file extensions ESLint must be told about, beyond `.ts` / `.js`. */
-export const frameworkExtensions = (framework: Framework): string[] => {
-  if (framework === "vue" || framework === "nuxt") return [".vue"];
-  if (framework === "svelte") return [".svelte"];
-  if (framework === "astro") return [".astro"];
-  return [];
-};
-
 /** Build output that must be ignored, or the first lint run reports thousands of generated files. */
 export const frameworkIgnores = (framework: Framework): string[] => {
   const shared = ["dist/**", "build/**", "coverage/**", "node_modules/**", ".vercel/**"];

--- a/src/detect/language.ts
+++ b/src/detect/language.ts
@@ -6,9 +6,9 @@ const JS_EXTENSIONS = new Set(["js", "jsx", "mjs", "cjs"]);
 /** Below this share of TypeScript, a repo with a tsconfig is still a JavaScript repo in practice. */
 const MIXED_THRESHOLD = 0.9;
 
-export const isTypeScriptFile = (file: SourceFile): boolean => TS_EXTENSIONS.has(file.ext);
+const isTypeScriptFile = (file: SourceFile): boolean => TS_EXTENSIONS.has(file.ext);
 
-export const isJavaScriptFile = (file: SourceFile): boolean => JS_EXTENSIONS.has(file.ext);
+const isJavaScriptFile = (file: SourceFile): boolean => JS_EXTENSIONS.has(file.ext);
 
 /**
  * Share of source files that are TypeScript. Returns 0 for an empty repo rather than NaN, so

--- a/src/detect/packageManager.ts
+++ b/src/detect/packageManager.ts
@@ -37,6 +37,3 @@ export const installCommand = (manager: PackageManager, packages: readonly strin
   if (manager === "bun") return `bun add --dev ${list}`;
   return `npm install --save-dev ${list}`;
 };
-
-export const runCommand = (manager: PackageManager, script: string): string =>
-  manager === "npm" ? `npm run ${script}` : `${manager} ${script}`;

--- a/src/detect/tooling.ts
+++ b/src/detect/tooling.ts
@@ -21,7 +21,7 @@ export const allDependencies = (packageJson: PackageJson | null): Record<string,
   ...packageJson?.devDependencies,
 });
 
-export const hasDependency = (packageJson: PackageJson | null, name: string): boolean =>
+const hasDependency = (packageJson: PackageJson | null, name: string): boolean =>
   name in allDependencies(packageJson);
 
 /**

--- a/src/eslintRunner.ts
+++ b/src/eslintRunner.ts
@@ -26,7 +26,7 @@ const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "
 
 export const formatterPath = (): string => path.join(packageRoot, "formatters", "rule-counts.js");
 
-export type EslintInvocation = {
+type EslintInvocation = {
   command: string;
   /** Arguments that come before ours — the entry script when going through Node. */
   prefixArgs: string[];
@@ -49,7 +49,7 @@ const exists = async (candidate: string): Promise<boolean> => {
  * which then has to quote paths that may contain spaces. Going straight to the `.js` sidesteps
  * both and behaves identically on every platform.
  */
-export const findEslint = async (cwd: string): Promise<EslintInvocation | null> => {
+const findEslint = async (cwd: string): Promise<EslintInvocation | null> => {
   const entry = path.join(cwd, "node_modules", "eslint", "bin", "eslint.js");
   if (await exists(entry)) {
     return { command: process.execPath, prefixArgs: [entry], shell: false };

--- a/src/facts.ts
+++ b/src/facts.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile, stat } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { exec } from "./util/exec.ts";
 import { countLines } from "./util/lines.ts";
@@ -110,12 +110,4 @@ export const gatherFacts = async (cwd: string): Promise<RepoFacts> => {
     sourceFiles: await Promise.all(sourcePaths.map((file) => toSourceFile(cwd, file))),
     workflows: await readWorkflows(cwd, files),
   };
-};
-
-export const isRepository = async (cwd: string): Promise<boolean> => {
-  try {
-    return (await stat(cwd)).isDirectory();
-  } catch {
-    return false;
-  }
 };

--- a/src/state.ts
+++ b/src/state.ts
@@ -2,8 +2,8 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Counter, Diagnosis, Phase, RuleBaseline, State } from "./types.ts";
 
-export const STATE_DIR = ".ever-better";
-export const STATE_FILE = "state.json";
+const STATE_DIR = ".ever-better";
+const STATE_FILE = "state.json";
 
 /**
  * ESLint's bulk suppressions cover errors only. Warnings therefore stay visible forever and would
@@ -19,7 +19,7 @@ export const WARNINGS_COUNTER = "eslint:warnings";
  */
 export type BaselineMode = "observe" | "freeze" | "rebaseline";
 
-export const statePath = (cwd: string): string => path.join(cwd, STATE_DIR, STATE_FILE);
+const statePath = (cwd: string): string => path.join(cwd, STATE_DIR, STATE_FILE);
 
 const isState = (value: unknown): value is State =>
   typeof value === "object" &&

--- a/src/suppressionsFile.ts
+++ b/src/suppressionsFile.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
-export const SUPPRESSIONS_FILE = "eslint-suppressions.json";
+const SUPPRESSIONS_FILE = "eslint-suppressions.json";
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;


### PR DESCRIPTION
## Summary

Acts on the scan added in #4. Twelve findings, all real:

- **Nine were exported out of habit** and used only inside their own module — now module-private:
  `isTypeScriptFile`, `isJavaScriptFile`, `hasDependency`, `STATE_DIR`, `STATE_FILE`, `statePath`,
  `SUPPRESSIONS_FILE`, `findEslint`, `EslintInvocation`.
- **Three had no caller anywhere** and are deleted: `frameworkExtensions`, `runCommand`,
  `isRepository`.

## Items to Confirm / Review

- **knip's inventory is now empty**, which is the property that makes its report usable at all: it
  has no base-branch diffing, so only an empty inventory makes "everything it lists" and "what this
  PR orphaned" the same list. Worth keeping at zero.
- `stat` is no longer imported in `facts.ts` — it existed solely for the deleted `isRepository`.
- No behaviour change; 102 tests unchanged and green.

## Gate

`format`, `lint`, `typecheck`, `test`, and `knip` reports nothing.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)