### PR TITLE
feat: ever-better-run — the unattended mode, and lead with it

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -20,6 +20,29 @@ npx ever-better check        # CI のゲート: 件数が増えたら失敗
 npx ever-better prune        # 直した分だけ天井を下げる
 ```
 
+## Claude Code に丸投げする
+
+こちらが本来の使い方です。プラグインを入れて、Claude Code をリポジトリに向けてこう言うだけ:
+
+```
+このレポに ever-better を回して
+```
+
+診断し、足りないものを導入し、フォーマットし、ベースラインを固定し、そこから**1ルール = 1 PR**でバックログを削っていきます。違反を直し、直すために必要な pure 関数を切り出し、テストを書き、天井を下げながら進みます。
+
+**コードから判断できることは全部自分で決めます。** GitHub issue を立てて先に進むのは、本当に判断が必要な数少ないケースだけです — 挙動が曖昧（throw すべきか、retry か、log か）、公開 API の変更、それ自体がプロジェクト規模のリファクタリング、そしてそのルール自体がこのレポに合っていない可能性がある場合。issue には選択肢と「自分ならこれを選ぶ」まで書きます。
+
+届く PR の順番: フォーマット → ツール導入 → freeze → 以降1ルールずつ。手つかずのリポジトリなら数本では済みません。始める前に知っておく価値があります。
+
+```
+/plugin marketplace add isamu/ever-better
+/plugin install ever-better
+```
+
+スキルは `ever-better-run`（上の無人ループ）、`ever-better`（入口とルーティング）、`ever-better-bootstrap`、`ever-better-freeze`、`ever-better-drain`、`ever-better-dry`。
+
+以下の CLI はこれらのスキルが呼ぶものですが、自分で動かしたい場合はそれだけでも使えます。
+
 ## なぜ必要か
 
 古いリポジトリに厳しい linter を入れると4000件のエラーが出て、そのまま revert されます。よくある回避策 — 全部を `warn` にする — では何も強制されず、件数は静かに増え続けます。
@@ -103,15 +126,7 @@ CI のゲート。抑制されていないエラーがある場合、または�
 
 ## Claude Code プラグイン
 
-このリポジトリは Claude Code のプラグインでもあります。CLI が意図的に持たない「判断」の部分 — このリポジトリではどの gap が重要か、この警告は本物のバグか、この関数をどう分割するか — をエージェントが担当します。
-
-```
-/plugin marketplace add isamu/ever-better
-/plugin install ever-better
-```
-
-スキル: `ever-better`（入口とルーティング）、`ever-better-bootstrap`、`ever-better-freeze`、
-`ever-better-drain`（P3）、`ever-better-dry`（P5）。
+冒頭に書いたとおり、プラグインが主役で CLI はそれが呼ぶ道具です。この分担は意図的なもので、CLI は毎回同じ結果でなければならない作業（検出・導入・集計・描画・ゲート）を、スキルは判断が要る作業（この警告は本物のバグか、これは重複か偶然か、何を issue にすべきか）を担当します。
 
 ## フェーズ
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,36 @@ npx ever-better check        # CI gate: fail if anything rose
 npx ever-better prune        # after a fix: reclaim the ceiling you earned
 ```
 
+## Hand it to Claude Code
+
+This is how it is meant to be used. Install the plugin, point Claude Code at a repository and say:
+
+```
+run ever-better on this repo
+```
+
+It diagnoses, installs what is missing, formats, freezes the baseline, then works the backlog down
+one rule per pull request — fixing violations, extracting the pure functions that make the fixes
+testable, writing the tests, and lowering the ceiling as it goes.
+
+**It decides everything it can from the code.** It opens a GitHub issue and moves on for the few
+things that are genuinely not its call: behaviour that is ambiguous (should this throw, retry or
+log?), a public API change, a refactor big enough to be its own project, or a rule that may simply
+be wrong for this repo. Each issue names the options and which one it would pick.
+
+What arrives, in order: a formatting PR, a tooling PR, a freeze PR, then one PR per rule. On an
+untouched repository that is more than a handful — worth knowing before you start it.
+
+```
+/plugin marketplace add isamu/ever-better
+/plugin install ever-better
+```
+
+The skills are `ever-better-run` (the unattended loop above), `ever-better` (entry point and
+routing), `ever-better-bootstrap`, `ever-better-freeze`, `ever-better-drain`, `ever-better-dry`.
+
+The CLI below is what those skills call, and it works on its own if you would rather drive.
+
 ## Why this exists
 
 Adding a strict linter to an old repository produces four thousand errors and gets reverted. The
@@ -131,17 +161,10 @@ are the ones to drain first.
 
 ## Claude Code plugin
 
-The repository is also a Claude Code plugin, so an agent can drive the phases with the judgment
-the CLI deliberately leaves out — which gaps matter for *this* repo, whether a warning is a real
-bug, how to split a function.
-
-```
-/plugin marketplace add isamu/ever-better
-/plugin install ever-better
-```
-
-Skills: `ever-better` (entry point and routing), `ever-better-bootstrap`, `ever-better-freeze`,
-`ever-better-drain` (P3), `ever-better-dry` (P5).
+Covered at the top — the plugin is the primary interface, and the CLI is what it calls. The split
+is deliberate: the CLI does what must be identical on every run (detect, install, count, render,
+gate), and the skills do what needs judgment (is this warning a real bug, is this duplication or
+coincidence, what deserves an issue).
 
 ## The phases
 

--- a/skills/ever-better-run/SKILL.md
+++ b/skills/ever-better-run/SKILL.md
@@ -1,0 +1,109 @@
+---
+description: Run the whole ever-better process on a repository unattended — diagnose, install, freeze, then drain the backlog rule by rule until it is empty, then duplication and dead code. Opens issues for the decisions it must not make alone and keeps going. Use when the user hands over a repo with "きれいにして", "全部やっておいて", "品質上げといて", "clean this repo up", "run ever-better on this", or asks for the process to run without supervision.
+---
+
+# ever-better run
+
+The unattended mode. The user has handed you a repository and expects to come back to pull
+requests, not questions.
+
+**Default to acting.** Everything in this process that can be decided from the code, you decide.
+The list of things that stop and ask is short and is written down below — if something is not on
+it, do it.
+
+## Before anything
+
+1. **Confirm the working tree is clean.** `git status --porcelain`. If it is not, stop and say so:
+   this process installs packages and rewrites files, and untangling that from someone's own work
+   afterwards is not worth the risk.
+2. **Confirm you may open pull requests**, and on which base branch. `gh repo view --json defaultBranchRef`.
+3. **Say how long this will take and what will arrive.** A first run on an untouched repository
+   produces: one formatting PR, one bootstrap PR, one freeze PR, then one PR per rule. That is not
+   two or three pull requests, and the user should know before you start.
+
+## The run
+
+### Phase 0-2: get to a frozen baseline
+
+```bash
+npx ever-better diagnose
+```
+
+Read it, then follow **`ever-better-bootstrap`** and **`ever-better-freeze`**. Three separate pull
+requests, in this order, each merged before the next:
+
+1. **`chore: format`** — mechanical, whole-repo, unreviewable if mixed with anything else.
+2. **`chore: quality tooling`** — the bootstrap output: ESLint config, scripts, `.gitattributes`,
+   workflows.
+3. **`chore: freeze the baseline`** — `eslint-suppressions.json`, `.ever-better/state.json`,
+   `QUALITY.md`.
+
+After (3), CI rejects any new violation. Everything from here is optional cleanup that can stop at
+any point without leaving the repo worse.
+
+### Phase 3: drain, until it is empty
+
+Loop with **`ever-better-drain`**. One rule per pull request, smallest backlog first:
+
+```
+npx ever-better status      -> smallest remaining rule
+   fix it, extract the pure function, write the test
+npx ever-better prune
+npx ever-better check
+   commit, PR, wait for CI, merge
+repeat
+```
+
+Keep going while the backlog is non-empty and nothing on the stop list below has come up. Report
+progress as you go — the ceiling before and after each PR is the number that matters.
+
+### Phase 4: tighten
+
+When the backlog is empty, add the next tier and freeze again. Type-aware rules first if the repo
+is TypeScript and they were off, then `eslint-plugin-security` if it touches the filesystem, child
+processes or user input. Each tier is a bootstrap + freeze pair, and then drain again.
+
+### Phase 5: duplication and dead code
+
+**`ever-better-dry`**. These are report-only and never gate, so this phase is pure cleanup.
+
+## The stop list
+
+Open a GitHub issue, then **continue with the next item** — do not wait:
+
+| Situation | Why it is not yours |
+| --- | --- |
+| The fix changes behaviour ambiguously | Should this throw, retry or log? That is a product decision. |
+| The fix changes a public API | A published signature, a wire format, a config key in someone's file. |
+| A refactor is a project in itself | Splitting a 2000-line file; a module that wants redesigning rather than editing. |
+| A rule looks wrong for this repo | The answer may be to configure the rule, not change the code. |
+| CI fails for a reason unrelated to your change | Flaky test, expired secret, broken runner. Report; do not "fix" it by disabling. |
+
+Each issue: the rule, the file and line, the two or three options, and which one you would pick
+with the reason. Then move on.
+
+**Stop the whole run** — and ask — only for these:
+
+- The working tree was dirty, or the repo has uncommitted work you did not create.
+- `freeze` reports violations it could not suppress. That is a broken config, and every later PR
+  would be red.
+- Two consecutive drain PRs fail CI for reasons you cannot diagnose.
+- The user's own CI was already failing before you started.
+
+## Reporting back
+
+When you stop — finished or blocked — say:
+
+- the ceiling at the start and now, and how many rules reached zero
+- every behaviour change you made, with the test that pins it
+- every issue you opened and why it was not yours to decide
+- what is left, and what running again would do
+
+## What this never does
+
+- Merges to the default branch without CI green.
+- Runs `freeze` a second time to make a red build green. It refuses; `--force` is not the answer.
+- Weakens a rule, adds an ignore comment, or widens an ignore glob to get past a failure. If a rule
+  is genuinely wrong for the repo, that is an issue, not an edit.
+- Rewrites an ESLint config the repo already had. The exceptions in it have reasons that are not in
+  the file.


### PR DESCRIPTION
## Summary

Handing the repo to Claude Code is the main way this gets used, and the README opened with a CLI
reference. Both READMEs now lead with it, and there is a skill for the whole unattended run.

```
run ever-better on this repo
```

## Items to Confirm / Review

1. **Two kinds of stopping, and the distinction is the whole design.** Things that become an issue
   and the run **continues** (ambiguous behaviour, public API change, project-sized refactor, a rule
   that may be wrong for this repo) versus the four that **stop and ask**: dirty working tree,
   `freeze` reporting unsuppressable violations, two consecutive unexplained CI failures, or CI that
   was already red before it started.
2. **The PR sequence is fixed**: format alone, then tooling, then freeze, then one per rule.
   Formatting has to land by itself or nothing after it is reviewable.
3. **It tells the user the volume up front.** A first run on an untouched repo is not two or three
   pull requests, and finding that out afterwards is a bad surprise.
4. **After the freeze PR, stopping is always safe** — CI already rejects new violations, and
   everything past that point is optional cleanup. That property is what makes handing it over
   reasonable at all.
5. **What it never does**, stated so it is not re-derived: no merge without green CI, no second
   `freeze` to clear a red build, no weakened rule or widened ignore glob, no rewriting an ESLint
   config the repo already had.

## Gate

`claude plugin validate . --strict` passes. Docs and one skill — no source change.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)