### PR TITLE
feat: worklist, work log, and a stale-diagnosis warning

### DIFF
--- a/.ever-better/state.json
+++ b/.ever-better/state.json
@@ -2,19 +2,23 @@
   "version": 1,
   "tool": "ever-better",
   "phase": "drain",
-  "updatedAt": "2026-08-07T23:05:09.294Z",
+  "updatedAt": "2026-08-08T00:32:37.843Z",
   "frozenAt": "2026-08-07T23:05:09.293Z",
   "diagnosis": {
     "packageManager": "yarn",
     "language": "typescript",
-    "typescriptFileRatio": 0.9696969696969697,
+    "framework": "none",
+    "runtime": "node",
+    "typescriptFileRatio": 0.9767441860465116,
     "tooling": {
       "eslint": "flat",
       "prettier": true,
       "testRunner": "node:test",
-      "knip": false,
-      "jscpd": false,
-      "agentInstructions": ["CLAUDE.md"]
+      "knip": true,
+      "jscpd": true,
+      "agentInstructions": [
+        "CLAUDE.md"
+      ]
     },
     "scripts": {
       "lint": true,
@@ -25,32 +29,26 @@
     },
     "ci": {
       "present": true,
-      "runners": ["macos-latest", "ubuntu-latest", "windows-latest"],
+      "runners": [
+        "macos-latest",
+        "ubuntu-latest",
+        "windows-latest"
+      ],
       "runsLint": true,
       "runsTest": true,
       "runsBuild": true,
       "runsTypecheck": true
     },
     "sizes": {
-      "total": 33,
+      "total": 43,
       "overFileLimit": 0,
       "largest": []
     },
-    "gaps": [
-      {
-        "id": "knip",
-        "title": "No dead-code detection",
-        "detail": "knip reports unused exports and files. Report-only at first; a counter later.",
-        "phase": "tighten"
-      },
-      {
-        "id": "jscpd",
-        "title": "No duplication detection",
-        "detail": "jscpd is what turns 'this feels repetitive' into a number that can only go down.",
-        "phase": "split"
-      }
-    ]
+    "gaps": []
   },
   "rules": {},
-  "counters": {}
+  "counters": {},
+  "diagnosedAt": "2026-08-08T00:32:37.842Z",
+  "diagnosedCommit": "a333b9f73eaed12ec2d5daba4c099c1d0d382e43",
+  "log": []
 }

--- a/QUALITY.md
+++ b/QUALITY.md
@@ -9,6 +9,17 @@ Maintained by [ever-better](https://github.com/isamu/ever-better). Numbers are r
 - Rules improved since the ceiling: **0**
 - Everything is at or below its ceiling.
 
+## Worklist
+
+Top to bottom. An unattended run works this list and nothing else.
+
+- [x] **P0 diagnose** — taken 2026-08-08T00:32:37.842Z
+- [x] **P1 bootstrap** — nothing missing
+- [x] **P2 freeze** — frozen 2026-08-07T23:05:09.293Z
+- [x] **P3 drain** — backlog empty
+- [ ] **P4 tighten** — add the next rule tier, then freeze and drain again
+- [ ] **P5 duplication and dead code** — report-only scans; extraction is judgment, not a threshold
+
 ## Ratchet
 
 Ceiling is the count at the last freeze. It may fall and must never rise.
@@ -17,13 +28,7 @@ No rule violations recorded yet. Run `ever-better freeze`.
 
 ## Outstanding
 
-### tighten
-
-- [ ] **No dead-code detection** — knip reports unused exports and files. Report-only at first; a counter later.
-
-### split
-
-- [ ] **No duplication detection** — jscpd is what turns 'this feels repetitive' into a number that can only go down.
+Nothing outstanding.
 
 ## Notes
 

--- a/skills/ever-better-run/SKILL.md
+++ b/skills/ever-better-run/SKILL.md
@@ -11,6 +11,44 @@ requests, not questions.
 The list of things that stop and ask is short and is written down below — if something is not on
 it, do it.
 
+## The checklist and the log are in the repo, not in your head
+
+`QUALITY.md` carries three sections this mode depends on, all rendered from
+`.ever-better/state.json`:
+
+- **Worklist** — the phases as checkboxes, with the smallest remaining rules as sub-items. Work it
+  top to bottom. It is derived from the numbers beside it, so it cannot drift from them.
+- **Carried over** — refactors deliberately not made, each stamped with the commit it was seen at.
+- **Work log** — what was drained, deferred, or turned into an issue, and when.
+
+Record as you go, not at the end:
+
+```bash
+npx ever-better log --kind drained  --rule max-depth "6 violations, 1 real bug (unreachable branch)"
+npx ever-better log --kind deferred --rule max-lines "server/router.ts is 1400 lines; splitting is its own project"
+npx ever-better log --kind issue    --rule no-floating-promises "opened #42 — swallowed error, product decision"
+```
+
+The commit stamp is the point. A note saying "router.ts needs splitting" is useless six months and
+four hundred commits later unless a reader can see when it was true.
+
+## Coming back to a repository you have not touched in a while
+
+**Re-diagnose first.** `ever-better status` prints a `STALE` line, and `QUALITY.md` opens with a
+warning, when the diagnosis is more than thirty days old, more than fifty commits behind, or was
+taken on a commit no longer in this history (a rebase or force-push). All three mean the same
+thing: file names and counts in the ledger may describe code that has moved.
+
+```bash
+npx ever-better diagnose --write
+```
+
+The ratchet itself never goes stale — `eslint-suppressions.json` is maintained by ESLint against
+the current tree. It is the *diagnosis* that ages: gap list, file sizes, and every deferred note.
+
+Re-read **Carried over** after re-diagnosing and drop the entries that no longer describe anything.
+A stale checklist that nobody prunes is how the list stops being read at all.
+
 ## Before anything
 
 1. **Confirm the working tree is clean.** `git status --porcelain`. If it is not, stop and say so:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { runBootstrap } from "./commands/bootstrap.ts";
 import { runCheck } from "./commands/check.ts";
 import { runDiagnose } from "./commands/diagnose.ts";
 import { runFreeze } from "./commands/freeze.ts";
+import { isLogKind, LOG_KIND_LIST, runLog } from "./commands/log.ts";
 import { runPrune } from "./commands/prune.ts";
 import { runStatus } from "./commands/status.ts";
 
@@ -18,6 +19,7 @@ const USAGE = `ever-better — make a codebase that can only get better
   prune       reclaim suppressions you have fixed     (lowers the ceiling)
   check       fail if anything rose above its ceiling (for CI)
   status      print the current backlog
+  log         record what happened, stamped with the current commit
 
 Options
   --cwd <dir>       target repository (default: current directory)
@@ -27,6 +29,8 @@ Options
   --force           freeze: allow a ceiling to move up
   --no-write        check: do not update the ledger
   --node <version>  node version for the generated workflow (default: ${DEFAULT_NODE_VERSION})
+  --kind <kind>     log: ${LOG_KIND_LIST}
+  --rule <name>     log: the rule this entry is about
 `;
 
 const OPTIONS = {
@@ -37,6 +41,8 @@ const OPTIONS = {
   force: { type: "boolean", default: false },
   "no-write": { type: "boolean", default: false },
   node: { type: "string", default: DEFAULT_NODE_VERSION },
+  kind: { type: "string", default: "note" },
+  rule: { type: "string" },
   help: { type: "boolean", default: false },
 } as const;
 
@@ -48,6 +54,9 @@ type Flags = {
   force: boolean;
   noWrite: boolean;
   node: string;
+  kind: string;
+  rule: string | undefined;
+  rest: string[];
 };
 
 const dispatch = async (
@@ -76,6 +85,15 @@ const dispatch = async (
     const result = await runCheck({ cwd: flags.cwd, write: !flags.noWrite });
     return { output: result.message, ok: result.ok };
   }
+  if (command === "log") {
+    if (!isLogKind(flags.kind))
+      return { output: `--kind must be one of: ${LOG_KIND_LIST}`, ok: false };
+    const text = flags.rest.join(" ").trim();
+    if (!text)
+      return { output: 'log needs text: ever-better log --kind deferred "..."', ok: false };
+    const output = await runLog({ cwd: flags.cwd, kind: flags.kind, text, rule: flags.rule });
+    return { output, ok: true };
+  }
   if (command === "status") {
     return { output: await runStatus({ cwd: flags.cwd, json: flags.json }), ok: true };
   }
@@ -103,6 +121,9 @@ const main = async (): Promise<number> => {
     force: values.force,
     noWrite: values["no-write"],
     node: values.node,
+    kind: values.kind,
+    rule: values.rule,
+    rest: positionals.slice(1),
   };
 
   const { output, ok } = await dispatch(command, flags);

--- a/src/commands/bootstrap.ts
+++ b/src/commands/bootstrap.ts
@@ -4,6 +4,7 @@ import { describeAction, planBootstrap, type BootstrapAction } from "../bootstra
 import { installCommand } from "../detect/packageManager.ts";
 import { diagnose } from "../diagnose.ts";
 import { gatherFacts } from "../facts.ts";
+import { headCommit } from "../git.ts";
 import { writeQualityFile } from "../qualityFile.ts";
 import { emptyState, readState, withDiagnosis, withPhase, writeState } from "../state.ts";
 import { exec } from "../util/exec.ts";
@@ -81,10 +82,8 @@ export const runBootstrap = async (options: BootstrapOptions): Promise<string> =
   }
 
   const after = diagnose(await gatherFacts(options.cwd));
-  const state = withPhase(
-    withDiagnosis((await readState(options.cwd)) ?? emptyState(), after),
-    "freeze",
-  );
+  const previous = (await readState(options.cwd)) ?? emptyState();
+  const state = withPhase(withDiagnosis(previous, after, await headCommit(options.cwd)), "freeze");
   await writeState(options.cwd, state);
   await writeQualityFile(options.cwd, state);
 

--- a/src/commands/diagnose.ts
+++ b/src/commands/diagnose.ts
@@ -1,5 +1,6 @@
 import { diagnose } from "../diagnose.ts";
 import { gatherFacts } from "../facts.ts";
+import { headCommit } from "../git.ts";
 import { writeQualityFile } from "../qualityFile.ts";
 import { renderReport } from "../render/report.ts";
 import { emptyState, readState, withDiagnosis, writeState } from "../state.ts";
@@ -15,7 +16,8 @@ export const runDiagnose = async (options: DiagnoseOptions): Promise<string> => 
   const diagnosis = diagnose(facts);
 
   if (options.write) {
-    const state = withDiagnosis((await readState(options.cwd)) ?? emptyState(), diagnosis);
+    const previous = (await readState(options.cwd)) ?? emptyState();
+    const state = withDiagnosis(previous, diagnosis, await headCommit(options.cwd));
     await writeState(options.cwd, state);
     await writeQualityFile(options.cwd, state);
   }

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -1,0 +1,36 @@
+import { headCommit } from "../git.ts";
+import { writeQualityFile } from "../qualityFile.ts";
+import { appendLog, emptyState, readState, writeState } from "../state.ts";
+import type { LogKind } from "../types.ts";
+
+export type LogOptions = {
+  cwd: string;
+  kind: LogKind;
+  text: string;
+  rule?: string;
+};
+
+const KINDS: readonly LogKind[] = ["drained", "deferred", "issue", "note"];
+
+export const isLogKind = (value: string): value is LogKind => KINDS.some((kind) => kind === value);
+
+export const LOG_KIND_LIST = KINDS.join(" | ");
+
+/**
+ * The record a later session reads instead of guessing. `deferred` is the one that matters: a
+ * refactor consciously not made, stamped with the commit it was seen at, so the next run can tell
+ * whether the observation still describes the code.
+ */
+export const runLog = async (options: LogOptions): Promise<string> => {
+  const previous = (await readState(options.cwd)) ?? emptyState();
+  const entry = {
+    kind: options.kind,
+    text: options.text,
+    ...(options.rule === undefined ? {} : { rule: options.rule }),
+    commit: await headCommit(options.cwd),
+  };
+  const state = appendLog(previous, entry);
+  await writeState(options.cwd, state);
+  await writeQualityFile(options.cwd, state);
+  return `Recorded ${options.kind}: ${options.text}`;
+};

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,3 +1,4 @@
+import { freshnessOf } from "../qualityFile.ts";
 import { findRegressions, improvements, readState, totalViolations } from "../state.ts";
 
 export type StatusOptions = {
@@ -12,12 +13,15 @@ export const runStatus = async (options: StatusOptions): Promise<string> => {
   if (!state) return "No .ever-better/state.json here. Start with `ever-better diagnose`.";
   if (options.json) return JSON.stringify(state, null, 2);
 
+  const freshness = await freshnessOf(options.cwd, state);
+
   const draining = Object.entries(state.rules)
     .filter(([, rule]) => rule.current > 0)
     .sort(([, a], [, b]) => a.current - b.current)
     .slice(0, NEXT_RULE_SAMPLE);
 
   return [
+    ...(freshness.stale ? [`STALE      ${freshness.reason}`, ""] : []),
     `phase      ${state.phase}`,
     `frozen     ${state.frozenAt ?? "never"}`,
     `backlog    ${totalViolations(state)}`,

--- a/src/freshness.ts
+++ b/src/freshness.ts
@@ -1,0 +1,59 @@
+/**
+ * A diagnosis is a photograph, and the repository keeps moving. An agent picking the ledger up
+ * weeks later has no way to tell whether "23 files over the limit" is today's number or one taken
+ * before a rewrite — so the ledger records WHEN and AT WHICH COMMIT it was taken, and this decides
+ * whether it can still be trusted.
+ */
+export type FreshnessInput = {
+  diagnosedAt: string | null;
+  diagnosedCommit: string | null;
+  headCommit: string | null;
+  /** Commits on HEAD that the diagnosis never saw. Null when it could not be computed. */
+  commitsSince: number | null;
+  now: Date;
+};
+
+export type Freshness = {
+  stale: boolean;
+  reason: string;
+};
+
+/** Enough churn that any file-level observation is likely to name something that has moved. */
+const STALE_COMMIT_COUNT = 50;
+
+/** Long enough that the dependency tree, and therefore the rule set, has probably changed. */
+const STALE_DAY_COUNT = 30;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const daysBetween = (from: string, to: Date): number | null => {
+  const start = Date.parse(from);
+  return Number.isNaN(start) ? null : Math.floor((to.getTime() - start) / MS_PER_DAY);
+};
+
+export const assessFreshness = (input: FreshnessInput): Freshness => {
+  if (!input.diagnosedAt || !input.diagnosedCommit) {
+    return { stale: true, reason: "never diagnosed — run `ever-better diagnose --write` first" };
+  }
+  const age = daysBetween(input.diagnosedAt, input.now);
+  if (age !== null && age >= STALE_DAY_COUNT) {
+    return {
+      stale: true,
+      reason: `diagnosis is ${age} days old; re-run diagnose before trusting it`,
+    };
+  }
+  if (input.commitsSince !== null && input.commitsSince >= STALE_COMMIT_COUNT) {
+    return {
+      stale: true,
+      reason: `${input.commitsSince} commits since the diagnosis; re-run diagnose before trusting it`,
+    };
+  }
+  if (
+    input.headCommit &&
+    input.headCommit !== input.diagnosedCommit &&
+    input.commitsSince === null
+  ) {
+    return { stale: true, reason: "HEAD moved since the diagnosis and the distance is unknown" };
+  }
+  return { stale: false, reason: "current" };
+};

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,0 +1,32 @@
+import { exec } from "./util/exec.ts";
+
+const shortSha = (raw: string): string | null => {
+  const trimmed = raw.trim();
+  return /^[0-9a-f]{7,40}$/.test(trimmed) ? trimmed : null;
+};
+
+export const headCommit = async (cwd: string): Promise<string | null> => {
+  try {
+    const result = await exec("git", ["rev-parse", "HEAD"], cwd);
+    return result.code === 0 ? shortSha(result.stdout) : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * How far the repository has moved since a diagnosis. Null when the recorded commit is not in this
+ * history at all — after a rebase, a force-push, or a fresh shallow clone — which is itself a
+ * reason to re-diagnose rather than a number to guess at.
+ */
+export const commitsSince = async (cwd: string, sha: string | null): Promise<number | null> => {
+  if (!sha) return null;
+  try {
+    const result = await exec("git", ["rev-list", "--count", `${sha}..HEAD`], cwd);
+    if (result.code !== 0) return null;
+    const count = Number.parseInt(result.stdout.trim(), 10);
+    return Number.isNaN(count) ? null : count;
+  } catch {
+    return null;
+  }
+};

--- a/src/qualityFile.ts
+++ b/src/qualityFile.ts
@@ -1,5 +1,7 @@
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { assessFreshness, type Freshness } from "./freshness.ts";
+import { commitsSince, headCommit } from "./git.ts";
 import { extractNotes, QUALITY_FILE, renderQuality } from "./render/quality.ts";
 import type { State } from "./types.ts";
 
@@ -11,10 +13,21 @@ const readIfPresent = async (filePath: string): Promise<string | null> => {
   }
 };
 
+export const freshnessOf = async (cwd: string, state: State): Promise<Freshness> => {
+  const head = await headCommit(cwd);
+  return assessFreshness({
+    diagnosedAt: state.diagnosedAt,
+    diagnosedCommit: state.diagnosedCommit,
+    headCommit: head,
+    commitsSince: await commitsSince(cwd, state.diagnosedCommit),
+    now: new Date(),
+  });
+};
+
 /** Re-renders QUALITY.md from state, carrying the owner's notes block across untouched. */
 export const writeQualityFile = async (cwd: string, state: State): Promise<string> => {
   const filePath = path.join(cwd, QUALITY_FILE);
   const notes = extractNotes(await readIfPresent(filePath));
-  await writeFile(filePath, renderQuality(state, notes), "utf8");
+  await writeFile(filePath, renderQuality(state, notes, await freshnessOf(cwd, state)), "utf8");
   return filePath;
 };

--- a/src/render/quality.ts
+++ b/src/render/quality.ts
@@ -1,5 +1,7 @@
-import { findRegressions, improvements, totalViolations } from "../state.ts";
-import type { Gap, RuleBaseline, State } from "../types.ts";
+import { findRegressions, improvements, logOfKind, totalViolations } from "../state.ts";
+import type { Freshness } from "../freshness.ts";
+import type { Gap, LogEntry, RuleBaseline, State } from "../types.ts";
+import { buildWorklist, renderWorklist } from "./worklist.ts";
 
 export const QUALITY_FILE = "QUALITY.md";
 
@@ -63,6 +65,59 @@ const gapsChecklist = (gaps: readonly Gap[]): string[] => {
   ]);
 };
 
+const LOG_ENTRIES_SHOWN = 20;
+
+const shortCommit = (commit: string | null): string => (commit ? commit.slice(0, 8) : "unknown");
+
+/**
+ * Deferred work is the section that decays. Each entry carries the commit it was written at, so a
+ * reader can see at a glance whether the observation predates half the repository.
+ */
+const rulePrefix = (rule: string | undefined): string => (rule ? `\`${rule}\` — ` : "");
+
+const provenance = (entry: LogEntry): string =>
+  `_(${entry.at.slice(0, 10)}, ${shortCommit(entry.commit)})_`;
+
+const carriedOver = (state: State): string[] => {
+  const deferred = logOfKind(state, "deferred");
+  if (deferred.length === 0) return [];
+  return [
+    "## Carried over",
+    "",
+    "Refactors left undone, with the commit each was seen at. Re-check before acting on an old one.",
+    "",
+    ...deferred.map(
+      (entry) => `- [ ] ${rulePrefix(entry.rule)}${entry.text}  ${provenance(entry)}`,
+    ),
+    "",
+  ];
+};
+
+const logRow = (entry: LogEntry): string =>
+  `| ${entry.at.slice(0, 10)} | ${shortCommit(entry.commit)} | ${entry.kind} | ${entry.rule ?? ""} | ${entry.text} |`;
+
+const workLog = (state: State): string[] => {
+  const entries = (state.log ?? []).slice(-LOG_ENTRIES_SHOWN).reverse();
+  if (entries.length === 0) return [];
+  return [
+    "## Work log",
+    "",
+    "| Date | Commit | Kind | Rule | What |",
+    "| --- | --- | --- | --- | --- |",
+    ...entries.map(logRow),
+    "",
+  ];
+};
+
+const freshnessBanner = (freshness: Freshness): string[] =>
+  freshness.stale
+    ? [
+        `> **The diagnosis below is stale** — ${freshness.reason}.`,
+        "> Numbers and file names may describe code that has since moved.",
+        "",
+      ]
+    : [];
+
 const headline = (state: State): string[] => {
   const regressions = findRegressions(state);
   const gained = improvements(state);
@@ -93,14 +148,22 @@ export const extractNotes = (existing: string | null): string => {
  * Pure: same state and same notes render the same file, so the diff on every run is exactly the
  * numbers that moved.
  */
-export const renderQuality = (state: State, notes: string): string =>
+export const renderQuality = (state: State, notes: string, freshness: Freshness): string =>
   [
     "# Quality",
     "",
     "Maintained by [ever-better](https://github.com/isamu/ever-better). Numbers are rendered from",
     "`.ever-better/state.json`; edits outside the notes block are overwritten on the next run.",
     "",
+    ...freshnessBanner(freshness),
     ...headline(state),
+    "## Worklist",
+    "",
+    "Top to bottom. An unattended run works this list and nothing else.",
+    "",
+    ...renderWorklist(buildWorklist(state)),
+    "",
+    ...carriedOver(state),
     "## Ratchet",
     "",
     "Ceiling is the count at the last freeze. It may fall and must never rise.",
@@ -110,6 +173,7 @@ export const renderQuality = (state: State, notes: string): string =>
     "## Outstanding",
     "",
     ...gapsChecklist(state.diagnosis?.gaps ?? []),
+    ...workLog(state),
     "## Notes",
     "",
     NOTES_START,

--- a/src/render/worklist.ts
+++ b/src/render/worklist.ts
@@ -1,0 +1,76 @@
+import { totalViolations } from "../state.ts";
+import type { State } from "../types.ts";
+
+export type WorklistItem = {
+  done: boolean;
+  label: string;
+  detail?: string;
+  children?: string[];
+};
+
+const NEXT_RULES_SHOWN = 5;
+
+const openBootstrapGaps = (state: State): number =>
+  (state.diagnosis?.gaps ?? []).filter((gap) => gap.phase === "bootstrap").length;
+
+const smallestBacklogs = (state: State): string[] =>
+  Object.entries(state.rules)
+    .filter(([, rule]) => rule.current > 0)
+    .sort(([, a], [, b]) => a.current - b.current)
+    .slice(0, NEXT_RULES_SHOWN)
+    .map(([name, rule]) => `\`${name}\` — ${rule.current} left`);
+
+/**
+ * The list an unattended run works down, top to bottom. Derived from state rather than stored, so
+ * it cannot drift from the numbers beside it — and so a session that picks this file up cold knows
+ * where it is without reading the log.
+ */
+export const buildWorklist = (state: State): WorklistItem[] => {
+  const bootstrapGaps = openBootstrapGaps(state);
+  const backlog = totalViolations(state);
+  const ruleCount = Object.values(state.rules).filter((rule) => rule.current > 0).length;
+
+  return [
+    {
+      done: state.diagnosedAt !== null,
+      label: "P0 diagnose",
+      detail: state.diagnosedAt ? `taken ${state.diagnosedAt}` : "not yet run",
+    },
+    {
+      done: state.diagnosedAt !== null && bootstrapGaps === 0,
+      label: "P1 bootstrap",
+      detail: bootstrapGaps === 0 ? "nothing missing" : `${bootstrapGaps} gap(s) still open`,
+    },
+    {
+      done: state.frozenAt !== null,
+      label: "P2 freeze",
+      detail: state.frozenAt ? `frozen ${state.frozenAt}` : "baseline not pinned yet",
+    },
+    {
+      done: state.frozenAt !== null && backlog === 0,
+      label: "P3 drain",
+      detail: backlog === 0 ? "backlog empty" : `${backlog} violations across ${ruleCount} rules`,
+      children: smallestBacklogs(state),
+    },
+    {
+      done: false,
+      label: "P4 tighten",
+      detail: "add the next rule tier, then freeze and drain again",
+    },
+    {
+      done: false,
+      label: "P5 duplication and dead code",
+      detail: "report-only scans; extraction is judgment, not a threshold",
+    },
+  ];
+};
+
+const checkbox = (done: boolean): string => (done ? "[x]" : "[ ]");
+
+const suffix = (detail: string | undefined): string => (detail ? ` — ${detail}` : "");
+
+export const renderWorklist = (items: readonly WorklistItem[]): string[] =>
+  items.flatMap((item) => [
+    `- ${checkbox(item.done)} **${item.label}**${suffix(item.detail)}`,
+    ...(item.children ?? []).map((child) => `  - [ ] ${child}`),
+  ]);

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-import type { Counter, Diagnosis, Phase, RuleBaseline, State } from "./types.ts";
+import type { Counter, Diagnosis, LogEntry, LogKind, Phase, RuleBaseline, State } from "./types.ts";
 
 const STATE_DIR = ".ever-better";
 const STATE_FILE = "state.json";
@@ -35,15 +35,26 @@ export const emptyState = (): State => ({
   phase: "diagnose",
   updatedAt: new Date().toISOString(),
   frozenAt: null,
+  diagnosedAt: null,
+  diagnosedCommit: null,
   diagnosis: null,
   rules: {},
   counters: {},
+  log: [],
+});
+
+/** 0.1.0 wrote neither `log` nor the diagnosis provenance; fill them rather than rejecting. */
+const migrate = (state: State): State => ({
+  ...state,
+  diagnosedAt: state.diagnosedAt ?? null,
+  diagnosedCommit: state.diagnosedCommit ?? null,
+  log: state.log ?? [],
 });
 
 export const readState = async (cwd: string): Promise<State | null> => {
   try {
     const parsed: unknown = JSON.parse(await readFile(statePath(cwd), "utf8"));
-    return isState(parsed) ? parsed : null;
+    return isState(parsed) ? migrate(parsed) : null;
   } catch {
     return null;
   }
@@ -55,10 +66,27 @@ export const writeState = async (cwd: string, state: State): Promise<void> => {
   await writeFile(statePath(cwd), `${JSON.stringify(stamped, null, 2)}\n`, "utf8");
 };
 
-export const withDiagnosis = (state: State, diagnosis: Diagnosis): State => ({
+export const withDiagnosis = (
+  state: State,
+  diagnosis: Diagnosis,
+  commit: string | null,
+): State => ({
   ...state,
   diagnosis,
+  diagnosedAt: new Date().toISOString(),
+  diagnosedCommit: commit,
 });
+
+/** Kept bounded: this file is read whole on every command, and a log is the thing that grows. */
+const MAX_LOG_ENTRIES = 200;
+
+export const appendLog = (state: State, entry: Omit<LogEntry, "at">): State => ({
+  ...state,
+  log: [...(state.log ?? []), { ...entry, at: new Date().toISOString() }].slice(-MAX_LOG_ENTRIES),
+});
+
+export const logOfKind = (state: State, kind: LogKind): LogEntry[] =>
+  (state.log ?? []).filter((entry) => entry.kind === kind);
 
 export const withPhase = (state: State, phase: Phase): State => ({ ...state, phase });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,13 +114,33 @@ export type Counter = {
   current: number;
 };
 
+/**
+ * `deferred` is the one that earns its keep: a refactor the agent decided not to make, recorded
+ * with the commit it was seen at, so a later session can tell whether the observation still
+ * describes the code.
+ */
+export type LogKind = "drained" | "deferred" | "issue" | "note";
+
+export type LogEntry = {
+  at: string;
+  /** HEAD when this was written. Without it a note cannot be aged. */
+  commit: string | null;
+  kind: LogKind;
+  rule?: string;
+  text: string;
+};
+
 export type State = {
   version: 1;
   tool: string;
   phase: Phase;
   updatedAt: string;
   frozenAt: string | null;
+  /** When and at which commit the diagnosis below was taken. */
+  diagnosedAt: string | null;
+  diagnosedCommit: string | null;
   diagnosis: Diagnosis | null;
   rules: Record<string, RuleBaseline>;
   counters: Record<string, Counter>;
+  log: LogEntry[];
 };

--- a/test/test_freshness.ts
+++ b/test/test_freshness.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { assessFreshness } from "../src/freshness.ts";
+import { buildWorklist } from "../src/render/worklist.ts";
+import { applyRuleCounts, appendLog, emptyState, logOfKind } from "../src/state.ts";
+
+const NOW = new Date("2026-08-08T00:00:00.000Z");
+
+const daysAgo = (days: number): string =>
+  new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000).toISOString();
+
+const input = (overrides: Partial<Parameters<typeof assessFreshness>[0]> = {}) => ({
+  diagnosedAt: daysAgo(1),
+  diagnosedCommit: "abc1234",
+  headCommit: "abc1234",
+  commitsSince: 0,
+  now: NOW,
+  ...overrides,
+});
+
+describe("assessFreshness", () => {
+  it("is fresh right after a diagnosis", () => {
+    assert.equal(assessFreshness(input()).stale, false);
+  });
+
+  it("is stale when there has never been one", () => {
+    const never = assessFreshness(input({ diagnosedAt: null, diagnosedCommit: null }));
+    assert.equal(never.stale, true);
+    assert.match(never.reason, /never diagnosed/);
+  });
+
+  it("goes stale with age, because the dependency tree moves under it", () => {
+    assert.equal(assessFreshness(input({ diagnosedAt: daysAgo(29) })).stale, false);
+    assert.equal(assessFreshness(input({ diagnosedAt: daysAgo(30) })).stale, true);
+  });
+
+  it("goes stale with churn, because file-level findings name files that moved", () => {
+    assert.equal(assessFreshness(input({ commitsSince: 49 })).stale, false);
+    const churned = assessFreshness(input({ commitsSince: 50 }));
+    assert.equal(churned.stale, true);
+    assert.match(churned.reason, /50 commits/);
+  });
+
+  it("is stale when HEAD moved and the distance cannot be computed", () => {
+    // A rebase or force-push leaves the recorded commit outside this history entirely, which is a
+    // reason to re-diagnose rather than a number to guess at.
+    const rebased = assessFreshness(input({ headCommit: "def5678", commitsSince: null }));
+    assert.equal(rebased.stale, true);
+  });
+
+  it("tolerates an unparseable timestamp rather than reporting stale on nonsense", () => {
+    assert.equal(assessFreshness(input({ diagnosedAt: "not a date" })).stale, false);
+  });
+});
+
+describe("buildWorklist", () => {
+  it("marks nothing done on a fresh state", () => {
+    assert.deepEqual(
+      buildWorklist(emptyState()).map((item) => item.done),
+      [false, false, false, false, false, false],
+    );
+  });
+
+  it("marks diagnose done once a diagnosis has been recorded", () => {
+    const state = { ...emptyState(), diagnosedAt: NOW.toISOString() };
+    assert.equal(buildWorklist(state)[0]?.done, true);
+  });
+
+  it("does not mark drain done while the backlog is non-empty", () => {
+    const frozen = {
+      ...applyRuleCounts(emptyState(), { "no-any": 3 }, "freeze"),
+      frozenAt: NOW.toISOString(),
+    };
+    const drain = buildWorklist(frozen).find((item) => item.label.startsWith("P3"));
+    assert.equal(drain?.done, false);
+    assert.match(drain?.detail ?? "", /3 violations/);
+  });
+
+  it("marks drain done when the backlog reaches zero", () => {
+    const frozen = applyRuleCounts(emptyState(), { "no-any": 3 }, "freeze");
+    const drained = { ...applyRuleCounts(frozen, {}, "observe"), frozenAt: NOW.toISOString() };
+    assert.equal(buildWorklist(drained).find((item) => item.label.startsWith("P3"))?.done, true);
+  });
+
+  it("lists the smallest backlogs as the children to work first", () => {
+    const frozen = {
+      ...applyRuleCounts(emptyState(), { big: 9, small: 1 }, "freeze"),
+      frozenAt: NOW.toISOString(),
+    };
+    const children = buildWorklist(frozen).find((item) => item.label.startsWith("P3"))?.children;
+    assert.match(children?.[0] ?? "", /small/);
+  });
+});
+
+describe("appendLog", () => {
+  it("stamps each entry and keeps them in order", () => {
+    const one = appendLog(emptyState(), {
+      kind: "deferred",
+      text: "split the big file",
+      commit: "a",
+    });
+    const two = appendLog(one, { kind: "drained", text: "max-depth to zero", commit: "b" });
+    assert.equal(two.log.length, 2);
+    assert.equal(two.log[1]?.text, "max-depth to zero");
+    assert.ok(two.log[0]?.at);
+  });
+
+  it("filters by kind, which is how the carried-over section is built", () => {
+    const state = appendLog(appendLog(emptyState(), { kind: "deferred", text: "d", commit: "a" }), {
+      kind: "note",
+      text: "n",
+      commit: "b",
+    });
+    assert.deepEqual(
+      logOfKind(state, "deferred").map((entry) => entry.text),
+      ["d"],
+    );
+  });
+
+  it("stays bounded, because every command reads this file whole", () => {
+    let state = emptyState();
+    for (let index = 0; index < 250; index += 1) {
+      state = appendLog(state, { kind: "note", text: `entry ${index}`, commit: null });
+    }
+    assert.equal(state.log.length, 200);
+    assert.equal(state.log[199]?.text, "entry 249");
+  });
+});

--- a/test/test_render.ts
+++ b/test/test_render.ts
@@ -4,6 +4,7 @@ import { renderEslintConfig } from "../src/generate/eslintConfig.ts";
 import { renderWorkflow } from "../src/generate/workflow.ts";
 import { extractNotes, NOTES_END, NOTES_START, renderQuality } from "../src/render/quality.ts";
 import { applyRuleCounts, emptyState } from "../src/state.ts";
+import type { Freshness } from "../src/freshness.ts";
 import type { Framework } from "../src/types.ts";
 
 const configOptions = {
@@ -140,26 +141,37 @@ describe("renderWorkflow", () => {
   });
 });
 
+const FRESH: Freshness = { stale: false, reason: "current" };
+
 describe("QUALITY.md", () => {
   const frozen = () => {
     const state = applyRuleCounts(emptyState(), { "no-any": 4, "max-depth": 1 }, "freeze");
     return { ...state, frozenAt: "2026-08-08T00:00:00.000Z" };
   };
 
-  it("lists the biggest backlog first", () => {
-    const rendered = renderQuality(frozen(), "");
-    const anyIndex = rendered.indexOf("no-any");
-    const depthIndex = rendered.indexOf("max-depth");
-    assert.ok(anyIndex < depthIndex);
+  // Scoped to one section on purpose: the worklist lists the SMALLEST backlog first and the
+  // ratchet table the largest, so an unscoped indexOf finds whichever section comes first and
+  // proves nothing about either.
+  const section = (rendered: string, from: string, to: string): string =>
+    rendered.slice(rendered.indexOf(from), rendered.indexOf(to));
+
+  it("lists the biggest backlog first in the ratchet table", () => {
+    const table = section(renderQuality(frozen(), "", FRESH), "## Ratchet", "## Outstanding");
+    assert.ok(table.indexOf("no-any") < table.indexOf("max-depth"));
+  });
+
+  it("puts the smallest backlog first in the worklist, which is the drain order", () => {
+    const worklist = section(renderQuality(frozen(), "", FRESH), "## Worklist", "## Ratchet");
+    assert.ok(worklist.indexOf("max-depth") < worklist.indexOf("no-any"));
   });
 
   it("shows a drop as a negative change", () => {
     const drained = applyRuleCounts(frozen(), { "no-any": 1, "max-depth": 1 }, "observe");
-    assert.match(renderQuality(drained, ""), /\| 4 \| 1 \| -3 \|/);
+    assert.match(renderQuality(drained, "", FRESH), /\| 4 \| 1 \| -3 \|/);
   });
 
   it("round-trips the owner's notes", () => {
-    const rendered = renderQuality(frozen(), "keep me");
+    const rendered = renderQuality(frozen(), "keep me", FRESH);
     assert.equal(extractNotes(rendered), "keep me");
   });
 
@@ -173,6 +185,6 @@ describe("QUALITY.md", () => {
   });
 
   it("is stable: the same state renders byte-identically", () => {
-    assert.equal(renderQuality(frozen(), "n"), renderQuality(frozen(), "n"));
+    assert.equal(renderQuality(frozen(), "n", FRESH), renderQuality(frozen(), "n", FRESH));
   });
 });


### PR DESCRIPTION
## Summary

An unattended run has to be resumable by a session that was not there when it stopped, and a
diagnosis taken months ago describes code that has since moved. Neither was represented anywhere.

`QUALITY.md` gains three sections, all rendered from state so they cannot drift from the numbers
beside them:

- **Worklist** — phases as checkboxes, smallest remaining rules as sub-items. Derived, not stored.
- **Carried over** — refactors deliberately not made, each stamped with the commit it was seen at.
- **Work log** — what was drained, deferred or made into an issue, and when.

New command:

```bash
ever-better log --kind drained|deferred|issue|note [--rule <name>] "what happened"
```

## Items to Confirm / Review

1. **The commit stamp is the whole point of the log.** "router.ts needs splitting" is useless four
   hundred commits later unless a reader can tell when it was true. Every entry records HEAD.
2. **Staleness thresholds: 30 days, 50 commits**, plus "the recorded commit is not in this history"
   — the last one catches a rebase or force-push, where the distance cannot be computed at all and
   guessing would be worse than saying so. Both numbers are named constants; say if they are wrong.
3. **The ratchet never goes stale, only the diagnosis does.** `eslint-suppressions.json` is
   maintained by ESLint against the current tree. It is the gap list, the file sizes and the
   deferred notes that age. The banner says so.
4. **The log is capped at 200 entries.** Every command reads this file whole and the log is the
   part that grows without bound.
5. **State written by 0.1.0 has neither `log` nor the diagnosis provenance.** `readState` migrates
   rather than rejecting, so an existing ledger keeps working.
6. One existing test had to be rescoped: it asserted "biggest backlog first" with an unscoped
   `indexOf`, which now finds the worklist (smallest first) instead of the ratchet table. It is
   split into two tests, one per section, with the reason in a comment.

## Verified

Dogfooded on this repo: logged a deferred entry, confirmed it renders under **Carried over** with
its date and short SHA, then cleared it.

## Gate

`format`, `lint`, `typecheck`, `build`, **117** tests, `knip` clean.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)