### PR TITLE
fix: keep Prettier off what ever-better generates

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,8 @@ dist/
 node_modules/
 *.md
 templates/
+
+# Machine-written; JSON.stringify always expands arrays that Prettier collapses.
+.ever-better/
+QUALITY.md
+eslint-suppressions.json

--- a/src/bootstrapPlan.ts
+++ b/src/bootstrapPlan.ts
@@ -6,6 +6,7 @@ import {
   renderEslintConfig,
 } from "./generate/eslintConfig.ts";
 import { renderGitattributes } from "./generate/gitattributes.ts";
+import { appendGeneratedPaths, renderPrettierIgnore } from "./generate/prettierIgnore.ts";
 import { renderWorkflow } from "./generate/workflow.ts";
 import type { Diagnosis, PackageJson, ScriptCoverage } from "./types.ts";
 
@@ -14,11 +15,15 @@ export type BootstrapAction =
   | { kind: "writeFile"; path: string; contents: string }
   | { kind: "addScripts"; scripts: Record<string, string> };
 
+export const PRETTIER_IGNORE_FILE = ".prettierignore";
+
 export type BootstrapPlanOptions = {
   diagnosis: Diagnosis;
   packageJson: PackageJson | null;
   rootEntries: readonly string[];
   nodeVersion: string;
+  /** Contents of an existing `.prettierignore`, so its generated paths can be appended. */
+  prettierIgnore: string | null;
 };
 
 const DEFAULT_TEST_GLOB = "test/**";
@@ -89,6 +94,8 @@ const filesToWrite = (options: BootstrapPlanOptions): BootstrapAction[] => {
     });
   }
 
+  actions.push(...prettierIgnoreAction(options));
+
   if (!rootEntries.includes(".gitattributes")) {
     actions.push({ kind: "writeFile", path: ".gitattributes", contents: renderGitattributes() });
   }
@@ -106,6 +113,20 @@ const filesToWrite = (options: BootstrapPlanOptions): BootstrapAction[] => {
   }
 
   return actions;
+};
+
+/**
+ * The only file bootstrap will edit rather than create. `.prettierignore` is line-based, so
+ * appending is well-defined; every other config carries decisions whose reasons are not in it.
+ */
+const prettierIgnoreAction = (options: BootstrapPlanOptions): BootstrapAction[] => {
+  if (options.prettierIgnore === null) {
+    return [{ kind: "writeFile", path: PRETTIER_IGNORE_FILE, contents: renderPrettierIgnore() }];
+  }
+  const appended = appendGeneratedPaths(options.prettierIgnore);
+  return appended === null
+    ? []
+    : [{ kind: "writeFile", path: PRETTIER_IGNORE_FILE, contents: appended }];
 };
 
 /** What the scripts WILL be once this plan is applied — the workflow must call those, not today's. */

--- a/src/commands/bootstrap.ts
+++ b/src/commands/bootstrap.ts
@@ -1,6 +1,11 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { describeAction, planBootstrap, type BootstrapAction } from "../bootstrapPlan.ts";
+import {
+  describeAction,
+  planBootstrap,
+  PRETTIER_IGNORE_FILE,
+  type BootstrapAction,
+} from "../bootstrapPlan.ts";
 import { installCommand } from "../detect/packageManager.ts";
 import { diagnose } from "../diagnose.ts";
 import { gatherFacts } from "../facts.ts";
@@ -14,6 +19,14 @@ export type BootstrapOptions = {
   cwd: string;
   dryRun: boolean;
   nodeVersion: string;
+};
+
+const readIfPresent = async (filePath: string): Promise<string | null> => {
+  try {
+    return await readFile(filePath, "utf8");
+  } catch {
+    return null;
+  }
 };
 
 const writeGeneratedFile = async (cwd: string, relativePath: string, contents: string) => {
@@ -70,6 +83,7 @@ export const runBootstrap = async (options: BootstrapOptions): Promise<string> =
     packageJson: facts.packageJson,
     rootEntries: facts.rootEntries,
     nodeVersion: options.nodeVersion,
+    prettierIgnore: await readIfPresent(path.join(options.cwd, PRETTIER_IGNORE_FILE)),
   });
 
   if (actions.length === 0) return "Nothing to install or generate. Run `ever-better freeze` next.";

--- a/src/generate/prettierIgnore.ts
+++ b/src/generate/prettierIgnore.ts
@@ -1,0 +1,23 @@
+/**
+ * Everything ever-better writes is machine-generated, and Prettier disagrees with all of it:
+ * `JSON.stringify(…, null, 2)` always expands arrays that Prettier would collapse. Without these
+ * lines the very first `diagnose --write` turns `format:check` red in CI, on a file the developer
+ * never touched.
+ */
+export const GENERATED_PATHS = [".ever-better/", "QUALITY.md", "eslint-suppressions.json"];
+
+const HEADER = "# Written by ever-better; machine-generated, so Prettier must not police it.";
+
+export const renderPrettierIgnore = (): string =>
+  ["dist/", "build/", "coverage/", "", HEADER, ...GENERATED_PATHS, ""].join("\n");
+
+/**
+ * `.prettierignore` is line-based, so appending is well-defined in a way that editing someone's
+ * config file is not. Returns null when the paths are already covered.
+ */
+export const appendGeneratedPaths = (existing: string): string | null => {
+  const missing = GENERATED_PATHS.filter((entry) => !existing.includes(entry));
+  if (missing.length === 0) return null;
+  const separator = existing.endsWith("\n") ? "" : "\n";
+  return `${existing}${separator}\n${HEADER}\n${missing.join("\n")}\n`;
+};

--- a/test/test_diagnose.ts
+++ b/test/test_diagnose.ts
@@ -66,12 +66,13 @@ describe("diagnose", () => {
 });
 
 describe("planBootstrap", () => {
-  const planFor = (input: RepoFacts) =>
+  const planFor = (input: RepoFacts, prettierIgnore: string | null = null) =>
     planBootstrap({
       diagnosis: diagnose(input),
       packageJson: input.packageJson,
       rootEntries: input.rootEntries,
       nodeVersion: "24",
+      prettierIgnore,
     });
 
   it("installs, adds scripts and writes configs for a bare repo", () => {
@@ -109,6 +110,17 @@ describe("planBootstrap", () => {
     assert.ok(!written.includes(".gitattributes"));
   });
 
+  it("writes a .prettierignore that excludes what ever-better generates", () => {
+    // Without it the first `diagnose --write` turns format:check red on a file the developer
+    // never touched: JSON.stringify always expands arrays that Prettier collapses.
+    const plan = planFor(facts());
+    const written = plan.filter((action) => action.kind === "writeFile");
+    const ignore = written.find((action) => action.path === ".prettierignore");
+    assert.ok(ignore?.kind === "writeFile");
+    assert.match(ignore.contents, /\.ever-better\//);
+    assert.match(ignore.contents, /eslint-suppressions\.json/);
+  });
+
   it("proposes no work at all for a repo that already has everything", () => {
     const complete = facts({
       rootEntries: [
@@ -140,7 +152,10 @@ describe("planBootstrap", () => {
       },
       workflows: [{ path: ".github/workflows/ci.yml", content: "run: yarn lint" }],
     });
-    assert.deepEqual(planFor(complete), []);
+    assert.deepEqual(
+      planFor(complete, ".ever-better/\nQUALITY.md\neslint-suppressions.json\n"),
+      [],
+    );
   });
 
   it("targets the generated workflow at the scripts it is about to add, not today's", () => {


### PR DESCRIPTION
## Summary

**main is currently red.** CI failed on all three platforms after #12 merged, on
`.ever-better/state.json` — a file no developer wrote. `JSON.stringify(…, null, 2)` always expands
arrays that Prettier collapses, so a generated ledger can never satisfy `format:check`.

This fixes main and fixes the same failure for every user: **bootstrap now generates a
`.prettierignore`** covering `.ever-better/`, `QUALITY.md` and `eslint-suppressions.json`. Without
it, every repository this tool touches goes red the first time anyone runs `diagnose --write`.

## Items to Confirm / Review

1. **`.prettierignore` is the one file bootstrap will EDIT rather than create.** It is line-based,
   so appending is well-defined; every other config carries decisions whose reasons are not written
   in it. If one exists and already covers the paths, nothing happens.
2. **My process error, worth stating.** I merged #12 while its checks were red — the wait loop
   exited on "not pending" and the merge ran unconditionally in the same command, so the result was
   never read. Enabling branch protection requiring `ci` on `main` would make that impossible;
   say the word and I will.

## Gate

`format:check`, `lint`, `typecheck`, `build`, 118 tests, `knip` clean.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)