### PR TITLE
feat: measure what is actually enforced, not what the config says

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,25 @@ that is largest.
 It is **plain JavaScript and never compiled** — it must load identically whether the CLI runs from
 `dist/` or from source. `formatterPath()` resolves it relative to the package root.
 
+## Ask the tool, do not read the config — and count with colour off
+
+`src/probe/` exists because a config file does not tell you what is enforced. Presets, a
+framework's own config and later blocks override each other silently, and a rule that ends up off
+reports nothing to notice. `eslint --print-config <file>` and `tsc --showConfig` are the only
+honest answers, and both are asked per-file / after `extends` for that reason.
+
+Two traps, both of which produced a wrong answer here before being fixed:
+
+- **`tsc` and `eslint` colour their output, so `grep -c "error TS"` matches nothing** and reports
+  a clean run. Three strictness flags were measured at "zero cost" that way and one of them had
+  six errors. Always pass `--pretty false` when counting.
+- **Measure a flag by enabling it in the tsconfig, not by passing it on the command line.** The
+  CLI form silently disagreed with the project form here.
+
+Type errors have no suppression mechanism — `--suppress-all` cannot touch them — so a strictness
+flag must be measured before it is switched on. Enabling one that costs 500 errors hands the owner
+a repo whose `typecheck` script fails, and nothing can grandfather that.
+
 ## Windows is not a formality
 
 Both Windows failures here passed on Linux and macOS first, and neither is reproducible locally on

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,6 +38,7 @@ export default tseslint.config(
       complexity: ["error", 15],
       "max-depth": ["error", 4],
       "max-nested-callbacks": ["error", 4],
+      "max-params": ["error", 6],
       "sonarjs/cognitive-complexity": ["error", 15],
     },
   },

--- a/src/bootstrapPlan.ts
+++ b/src/bootstrapPlan.ts
@@ -51,12 +51,12 @@ const missingPackages = (options: BootstrapPlanOptions): string[] => {
 const scriptsToAdd = (options: BootstrapPlanOptions): Record<string, string> => {
   const { scripts, language, tooling } = options.diagnosis;
   const additions: Record<string, string> = {};
-  if (!scripts.lint) additions.lint = "eslint .";
-  if (!scripts.format) additions.format = "prettier --write .";
+  if (!scripts.lint) additions["lint"] = "eslint .";
+  if (!scripts.format) additions["format"] = "prettier --write .";
   if (!scripts.typecheck && language !== "javascript") {
-    additions.typecheck = typecheckCommand(options.diagnosis.framework);
+    additions["typecheck"] = typecheckCommand(options.diagnosis.framework);
   }
-  if (!scripts.test && tooling.testRunner === "none") additions.test = "vitest run";
+  if (!scripts.test && tooling.testRunner === "none") additions["test"] = "vitest run";
   return additions;
 };
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -91,7 +91,9 @@ const dispatch = async (
     const text = flags.rest.join(" ").trim();
     if (!text)
       return { output: 'log needs text: ever-better log --kind deferred "..."', ok: false };
-    const output = await runLog({ cwd: flags.cwd, kind: flags.kind, text, rule: flags.rule });
+    // exactOptionalPropertyTypes: an optional property must be OMITTED, not set to undefined.
+    const rule = flags.rule === undefined ? {} : { rule: flags.rule };
+    const output = await runLog({ cwd: flags.cwd, kind: flags.kind, text, ...rule });
     return { output, ok: true };
   }
   if (command === "status") {

--- a/src/detect/tooling.ts
+++ b/src/detect/tooling.ts
@@ -37,7 +37,7 @@ export const detectEslintSetup = (rootEntries: readonly string[]): EslintSetup =
 export const detectTestRunner = (packageJson: PackageJson | null): TestRunner => {
   if (hasDependency(packageJson, "vitest")) return "vitest";
   if (hasDependency(packageJson, "jest")) return "jest";
-  const testScript = packageJson?.scripts?.test ?? "";
+  const testScript = packageJson?.scripts?.["test"] ?? "";
   if (testScript.includes("node --test") || testScript.includes("node:test")) return "node:test";
   return "none";
 };

--- a/src/diagnose.ts
+++ b/src/diagnose.ts
@@ -4,6 +4,8 @@ import { detectLanguageMode, typescriptFileRatio } from "./detect/language.ts";
 import { detectPackageManager } from "./detect/packageManager.ts";
 import { summarizeSizes, DEFAULT_FILE_LINE_LIMIT } from "./detect/sizes.ts";
 import { detectScripts, detectTooling } from "./detect/tooling.ts";
+import { findWeakRules } from "./probe/effectiveRules.ts";
+import { findMissingStrictness, isStrictOff } from "./probe/effectiveTsconfig.ts";
 import type { Diagnosis, Gap, RepoFacts, ScriptCoverage } from "./types.ts";
 
 const REQUIRED_SCRIPTS: readonly (keyof ScriptCoverage)[] = [
@@ -180,6 +182,61 @@ const frameworkGaps = (diagnosis: Omit<Diagnosis, "gaps">, facts: RepoFacts): Ga
   ];
 };
 
+const MAX_NAMED_RULES = 6;
+
+/**
+ * The gap nothing else can see. A repo can have a config file, a strict preset and a green build
+ * while the rules that find real bugs are silently off — presets and framework configs override
+ * each other, and a rule that is off reports nothing. This asks ESLint instead of reading the file.
+ */
+const effectiveRuleGaps = (facts: RepoFacts): Gap[] => {
+  const weak = findWeakRules(facts.probes.rules);
+  if (weak.length === 0) return [];
+  const off = weak.filter((verdict) => verdict.state === "off");
+  const named = weak.slice(0, MAX_NAMED_RULES).map((verdict) => verdict.rule.name);
+  const more = weak.length > MAX_NAMED_RULES ? `, and ${weak.length - MAX_NAMED_RULES} more` : "";
+  return [
+    {
+      id: "weak-rules",
+      title: `${weak.length} high-value rules are not enforcing (${off.length} off, ${weak.length - off.length} warn-only)`,
+      detail:
+        `Measured with \`eslint --print-config\`, not read from the config: ${named.join(", ")}${more}. ` +
+        "Each of these has cost somebody real bugs, and a rule that is off reports nothing to notice.",
+      phase: "tighten",
+    },
+  ];
+};
+
+/**
+ * `strict: true` does not include these, which is the trap: a repo sets strict, believes it is
+ * done, and never learns that indexing an array still hands back a value typed as present.
+ */
+const strictnessGaps = (facts: RepoFacts): Gap[] => {
+  if (!facts.probes.tsconfig) return [];
+  if (isStrictOff(facts.probes.tsconfig)) {
+    return [
+      {
+        id: "tsconfig-strict",
+        title: "TypeScript `strict` is off",
+        detail: "Everything else in the type tier is moot until this is on.",
+        phase: "tighten",
+      },
+    ];
+  }
+  const missing = findMissingStrictness(facts.probes.tsconfig);
+  if (missing.length === 0) return [];
+  return [
+    {
+      id: "tsconfig-strictness",
+      title: `${missing.length} strictness flags \`strict\` does not include are off`,
+      detail:
+        `Measured with \`tsc --showConfig\`, after every extends: ${missing.map((entry) => entry.flag.name).join(", ")}. ` +
+        "Type errors have no suppression mechanism, so enable them one at a time and measure the cost first.",
+      phase: "tighten",
+    },
+  ];
+};
+
 const GAP_DETECTORS = [eslintGaps, languageGaps, toolingGaps, scriptGaps, ciGaps, sizeGaps];
 
 /**
@@ -204,6 +261,8 @@ export const diagnose = (facts: RepoFacts): Diagnosis => {
   const gaps = [
     ...GAP_DETECTORS.flatMap((detect) => detect(partial)),
     ...frameworkGaps(partial, facts),
+    ...effectiveRuleGaps(facts),
+    ...strictnessGaps(facts),
   ];
   return { ...partial, gaps };
 };

--- a/src/eslintRunner.ts
+++ b/src/eslintRunner.ts
@@ -62,6 +62,9 @@ const findEslint = async (cwd: string): Promise<EslintInvocation | null> => {
   return null;
 };
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
 const isRuleCounts = (value: unknown): value is RuleCounts =>
   typeof value === "object" && value !== null && "errors" in value && "suppressed" in value;
 
@@ -112,6 +115,34 @@ export const runRuleCounts = async (cwd: string): Promise<RuleCounts> => {
  */
 export const suppressAll = async (cwd: string): Promise<void> => {
   await runEslint(cwd, [".", "--suppress-all"], "eslint --suppress-all");
+};
+
+/**
+ * What ESLint will ACTUALLY apply to one file. Reading the config source cannot answer this:
+ * presets, a framework's own config and later blocks all override each other silently, and a rule
+ * that ends up off reports nothing to notice.
+ *
+ * Returns null rather than throwing — a repo without ESLint is the normal case here.
+ */
+export const printConfig = async (
+  cwd: string,
+  filePath: string,
+): Promise<Record<string, unknown> | null> => {
+  const eslint = await findEslint(cwd);
+  if (!eslint) return null;
+  try {
+    const result = await exec(
+      eslint.command,
+      [...eslint.prefixArgs, "--print-config", filePath],
+      cwd,
+      { shell: eslint.shell },
+    );
+    if (result.code !== 0) return null;
+    const parsed: unknown = JSON.parse(result.stdout);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
 };
 
 /** Drops suppressions for violations that no longer exist, which is how the ceiling comes down. */

--- a/src/facts.ts
+++ b/src/facts.ts
@@ -2,6 +2,7 @@ import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { exec } from "./util/exec.ts";
 import { countLines } from "./util/lines.ts";
+import { gatherProbes } from "./probe/gather.ts";
 import type { PackageJson, RepoFacts, SourceFile, WorkflowFile } from "./types.ts";
 
 const SOURCE_EXTENSIONS = new Set([
@@ -103,11 +104,13 @@ export const gatherFacts = async (cwd: string): Promise<RepoFacts> => {
   const sourcePaths = files.filter(
     (file) => SOURCE_EXTENSIONS.has(extensionOf(file)) && !CONFIG_FILE_PATTERN.test(file),
   );
+  const sourceFiles = await Promise.all(sourcePaths.map((file) => toSourceFile(cwd, file)));
   return {
     cwd,
     rootEntries: rootEntriesOf(files),
     packageJson: await readPackageJson(cwd),
-    sourceFiles: await Promise.all(sourcePaths.map((file) => toSourceFile(cwd, file))),
+    sourceFiles,
     workflows: await readWorkflows(cwd, files),
+    probes: await gatherProbes(cwd, sourceFiles),
   };
 };

--- a/src/generate/eslintConfig.ts
+++ b/src/generate/eslintConfig.ts
@@ -95,6 +95,7 @@ const limitsBlock = (options: EslintConfigOptions): string[] => [
   '      complexity: ["error", 20],',
   '      "max-depth": ["error", 4],',
   '      "max-nested-callbacks": ["error", 4],',
+  '      "max-params": ["error", 6],',
   '      "sonarjs/cognitive-complexity": ["error", 15],',
   "    },",
   "  },",

--- a/src/probe/effectiveRules.ts
+++ b/src/probe/effectiveRules.ts
@@ -1,0 +1,102 @@
+/**
+ * What a config file SAYS and what ESLint actually runs are different things. Preset inheritance,
+ * a framework's own config and later blocks all silently drop rules, and a rule that is off
+ * reports nothing — so the gap is invisible from the outside and from reading the file.
+ *
+ * `--print-config` is ESLint's own answer to that question. Everything here works from its output
+ * rather than from the config source.
+ */
+export type PrintedConfig = {
+  rules?: Record<string, unknown>;
+};
+
+export type HighValueRule = {
+  name: string;
+  why: string;
+};
+
+/**
+ * Rules worth reporting as off. Each one has cost somebody real bugs — the counts in the linked
+ * write-up were 149 unchecked `as` casts and 407 unsafe-any findings in a repo its author believed
+ * was already strict.
+ */
+export const HIGH_VALUE_RULES: readonly HighValueRule[] = [
+  { name: "@typescript-eslint/no-explicit-any", why: "`any` switches off every other type rule" },
+  {
+    name: "@typescript-eslint/no-unsafe-assignment",
+    why: "unvalidated JSON and API responses flow in as `any`",
+  },
+  { name: "@typescript-eslint/no-unsafe-member-access", why: "reads through an unchecked `any`" },
+  { name: "@typescript-eslint/no-unsafe-call", why: "calls through an unchecked `any`" },
+  { name: "@typescript-eslint/no-unsafe-return", why: "leaks `any` back out to callers" },
+  { name: "@typescript-eslint/no-unsafe-argument", why: "passes `any` into a typed parameter" },
+  { name: "@typescript-eslint/no-floating-promises", why: "a forgotten await fails silently" },
+  {
+    name: "@typescript-eslint/no-misused-promises",
+    why: "an async callback where none is awaited",
+  },
+  { name: "@typescript-eslint/await-thenable", why: "awaiting a non-promise hides a missing call" },
+  {
+    name: "@typescript-eslint/consistent-type-assertions",
+    why: "`as` asserts what the compiler could not check; it lives in the stylistic preset, not strict",
+  },
+  { name: "@typescript-eslint/no-non-null-assertion", why: "`!` is an unchecked claim" },
+  {
+    name: "sonarjs/cognitive-complexity",
+    why: "how hard a function is for a human, not a machine",
+  },
+  {
+    name: "max-lines-per-function",
+    why: "the guard that keeps a function comprehensible at a glance",
+  },
+  {
+    name: "max-lines",
+    why: "per-file size; the per-function guards pass while a file reaches 2000 lines",
+  },
+  { name: "complexity", why: "branch count" },
+  { name: "max-depth", why: "nesting" },
+  { name: "max-params", why: "argument count" },
+];
+
+const OFF_LEVELS = new Set<number | string>([0, "off"]);
+
+/** ESLint prints a level, or `[level, ...options]`. Both forms have to be read the same way. */
+const severityOf = (setting: unknown): number | string | null => {
+  const level: unknown = Array.isArray(setting) ? setting[0] : setting;
+  if (typeof level === "number" || typeof level === "string") return level;
+  return null;
+};
+
+export const isRuleOff = (setting: unknown): boolean => {
+  const level = severityOf(setting);
+  return level === null || OFF_LEVELS.has(level);
+};
+
+export const isRuleWarnOnly = (setting: unknown): boolean => {
+  const level = severityOf(setting);
+  return level === 1 || level === "warn";
+};
+
+export type RuleVerdict = {
+  rule: HighValueRule;
+  state: "off" | "warn";
+};
+
+/**
+ * Pure: given what ESLint printed, which of the rules that matter are not enforcing anything.
+ * `warn` is reported separately because it is a deliberate stop on the way to `error` — but one
+ * that stays there forever unless somebody is counting.
+ */
+export const findWeakRules = (
+  printed: PrintedConfig | null,
+  wanted: readonly HighValueRule[] = HIGH_VALUE_RULES,
+): RuleVerdict[] => {
+  if (!printed) return [];
+  const rules = printed.rules ?? {};
+  return wanted.flatMap((rule): RuleVerdict[] => {
+    const setting = rules[rule.name];
+    if (isRuleOff(setting)) return [{ rule, state: "off" }];
+    if (isRuleWarnOnly(setting)) return [{ rule, state: "warn" }];
+    return [];
+  });
+};

--- a/src/probe/effectiveTsconfig.ts
+++ b/src/probe/effectiveTsconfig.ts
@@ -1,0 +1,65 @@
+export type CompilerOptions = Record<string, unknown>;
+
+export type ShownConfig = {
+  compilerOptions?: CompilerOptions;
+};
+
+export type StrictnessFlag = {
+  name: string;
+  why: string;
+};
+
+/**
+ * `strict: true` does NOT turn these on. That is the trap: a repo sets `strict`, believes it is
+ * done, and never learns that indexing an array still hands back a value typed as present.
+ *
+ * In strict and therefore absent from this list: noImplicitAny, noImplicitThis, strictNullChecks,
+ * strictFunctionTypes, strictBindCallApply, strictPropertyInitialization, alwaysStrict,
+ * useUnknownInCatchVariables.
+ */
+export const STRICTNESS_FLAGS: readonly StrictnessFlag[] = [
+  {
+    name: "noUncheckedIndexedAccess",
+    why: "without it `array[i]` is typed as present even when the array is empty",
+  },
+  {
+    name: "exactOptionalPropertyTypes",
+    why: "without it `{ a?: string }` silently accepts an explicit undefined",
+  },
+  { name: "noImplicitReturns", why: "a branch that forgets to return yields undefined" },
+  { name: "noFallthroughCasesInSwitch", why: "a missing break falls into the next case" },
+  {
+    name: "noImplicitOverride",
+    why: "a renamed base method leaves an override that overrides nothing",
+  },
+  {
+    name: "noPropertyAccessFromIndexSignature",
+    why: "a typo on an index-signature type resolves instead of erroring",
+  },
+];
+
+const isEnabled = (value: unknown): boolean => value === true;
+
+export type FlagVerdict = {
+  flag: StrictnessFlag;
+};
+
+/**
+ * Pure: given what `tsc --showConfig` resolved to — which is the value after every `extends` and
+ * every framework preset — which strictness flags are still off.
+ */
+export const findMissingStrictness = (
+  shown: ShownConfig | null,
+  wanted: readonly StrictnessFlag[] = STRICTNESS_FLAGS,
+): FlagVerdict[] => {
+  if (!shown) return [];
+  const options = shown.compilerOptions ?? {};
+  return wanted.filter((flag) => !isEnabled(options[flag.name])).map((flag) => ({ flag }));
+};
+
+/** `strict` itself being off makes every flag above moot — report that first, not six times. */
+export const isStrictOff = (shown: ShownConfig | null): boolean => {
+  if (!shown) return false;
+  const options = shown.compilerOptions ?? {};
+  return !isEnabled(options["strict"]) && !isEnabled(options["strictNullChecks"]);
+};

--- a/src/probe/gather.ts
+++ b/src/probe/gather.ts
@@ -1,0 +1,59 @@
+import path from "node:path";
+import { printConfig } from "../eslintRunner.ts";
+import { exec } from "../util/exec.ts";
+import type { PrintedConfig } from "./effectiveRules.ts";
+import type { ShownConfig } from "./effectiveTsconfig.ts";
+import type { SourceFile } from "../types.ts";
+
+export type Probes = {
+  rules: PrintedConfig | null;
+  tsconfig: ShownConfig | null;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const parseObject = (text: string): Record<string, unknown> | null => {
+  try {
+    const parsed: unknown = JSON.parse(text);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Which file to ask about. Rules are configured per glob, so the answer for a `.d.ts`, a spec or a
+ * config file says nothing about the code — prefer TypeScript under a source path, because that is
+ * where the type-aware rules apply at all.
+ */
+export const sampleSourceFile = (sourceFiles: readonly SourceFile[]): SourceFile | null => {
+  const candidates = sourceFiles.filter(
+    (file) => !file.path.endsWith(".d.ts") && !file.path.includes("test"),
+  );
+  const typed = candidates.filter((file) => file.ext === "ts" || file.ext === "tsx");
+  return typed[0] ?? candidates[0] ?? sourceFiles[0] ?? null;
+};
+
+/** `--showConfig` resolves every `extends` first, so it reports what the compiler will really use. */
+const probeTsconfig = async (cwd: string): Promise<ShownConfig | null> => {
+  const entry = path.join(cwd, "node_modules", "typescript", "bin", "tsc");
+  try {
+    const result = await exec(process.execPath, [entry, "--showConfig"], cwd);
+    return result.code === 0 ? parseObject(result.stdout) : null;
+  } catch {
+    return null;
+  }
+};
+
+/** Both probes shell out, both tolerate absence, and neither is fatal. */
+export const gatherProbes = async (
+  cwd: string,
+  sourceFiles: readonly SourceFile[],
+): Promise<Probes> => {
+  const sample = sampleSourceFile(sourceFiles);
+  return {
+    rules: sample ? await printConfig(cwd, sample.path) : null,
+    tsconfig: await probeTsconfig(cwd),
+  };
+};

--- a/src/suppressionsFile.ts
+++ b/src/suppressionsFile.ts
@@ -7,7 +7,7 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
 const isCountEntry = (value: unknown): value is { count: number } =>
-  isRecord(value) && typeof value.count === "number";
+  isRecord(value) && typeof value["count"] === "number";
 
 /**
  * Sum of every recorded suppression. Written by ESLint as `{ file: { rule: { count } } }`, so its

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,8 @@ export type WorkflowFile = {
  */
 export type RepoFacts = {
   cwd: string;
+  /** What ESLint and tsc report as EFFECTIVE, which is not what the config files say. */
+  probes: import("./probe/gather.ts").Probes;
   /** Repo-relative paths of files in the repository root (not recursive). */
   rootEntries: string[];
   packageJson: PackageJson | null;

--- a/test/test_diagnose.ts
+++ b/test/test_diagnose.ts
@@ -10,6 +10,7 @@ const facts = (overrides: Partial<RepoFacts> = {}): RepoFacts => ({
   packageJson: { name: "demo" },
   sourceFiles: [],
   workflows: [],
+  probes: { rules: null, tsconfig: null },
   ...overrides,
 });
 

--- a/test/test_probe.ts
+++ b/test/test_probe.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  findWeakRules,
+  isRuleOff,
+  isRuleWarnOnly,
+  HIGH_VALUE_RULES,
+} from "../src/probe/effectiveRules.ts";
+import { findMissingStrictness, isStrictOff } from "../src/probe/effectiveTsconfig.ts";
+import { sampleSourceFile } from "../src/probe/gather.ts";
+import type { SourceFile } from "../src/types.ts";
+
+const file = (path: string): SourceFile => ({
+  path,
+  ext: path.split(".").pop() ?? "",
+  lines: 10,
+});
+
+describe("rule severity", () => {
+  it("reads both the bare level and the [level, options] form", () => {
+    assert.equal(isRuleOff("off"), true);
+    assert.equal(isRuleOff(0), true);
+    assert.equal(isRuleOff(["off", { max: 5 }]), true);
+    assert.equal(isRuleOff(["error", { max: 5 }]), false);
+  });
+
+  it("treats a rule ESLint never mentioned as off", () => {
+    assert.equal(isRuleOff(undefined), true);
+  });
+
+  it("separates warn from error, because warn enforces nothing", () => {
+    assert.equal(isRuleWarnOnly("warn"), true);
+    assert.equal(isRuleWarnOnly(1), true);
+    assert.equal(isRuleWarnOnly("error"), false);
+    assert.equal(isRuleWarnOnly(["warn", { max: 5 }]), true);
+  });
+});
+
+describe("findWeakRules", () => {
+  const allOn = Object.fromEntries(HIGH_VALUE_RULES.map((rule) => [rule.name, "error"]));
+
+  it("reports nothing when every rule is an error", () => {
+    assert.deepEqual(findWeakRules({ rules: allOn }), []);
+  });
+
+  it("reports a rule ESLint did not mention at all", () => {
+    const rules = { ...allOn };
+    delete rules[HIGH_VALUE_RULES[0]?.name ?? ""];
+    const weak = findWeakRules({ rules });
+    assert.equal(weak.length, 1);
+    assert.equal(weak[0]?.state, "off");
+  });
+
+  it("separates warn-only from off, because they need different answers", () => {
+    const name = HIGH_VALUE_RULES[0]?.name ?? "";
+    const weak = findWeakRules({ rules: { ...allOn, [name]: "warn" } });
+    assert.deepEqual(
+      weak.map((verdict) => verdict.state),
+      ["warn"],
+    );
+  });
+
+  it("reports nothing when ESLint could not be asked", () => {
+    // A repo without ESLint is the normal input, not an error.
+    assert.deepEqual(findWeakRules(null), []);
+  });
+});
+
+describe("findMissingStrictness", () => {
+  it("reports a flag that `strict` does not include", () => {
+    // strict: true enables none of these, which is exactly the trap.
+    const missing = findMissingStrictness({ compilerOptions: { strict: true } });
+    const names = missing.map((entry) => entry.flag.name);
+    assert.ok(names.includes("noUncheckedIndexedAccess"));
+    assert.ok(names.includes("exactOptionalPropertyTypes"));
+  });
+
+  it("reports nothing once they are all on", () => {
+    const compilerOptions = {
+      noUncheckedIndexedAccess: true,
+      exactOptionalPropertyTypes: true,
+      noImplicitReturns: true,
+      noFallthroughCasesInSwitch: true,
+      noImplicitOverride: true,
+      noPropertyAccessFromIndexSignature: true,
+    };
+    assert.deepEqual(findMissingStrictness({ compilerOptions }), []);
+  });
+
+  it("treats a flag set to false as off, not as configured", () => {
+    const missing = findMissingStrictness({ compilerOptions: { noImplicitReturns: false } });
+    assert.ok(missing.some((entry) => entry.flag.name === "noImplicitReturns"));
+  });
+
+  it("reports nothing when tsc could not be asked", () => {
+    assert.deepEqual(findMissingStrictness(null), []);
+  });
+});
+
+describe("isStrictOff", () => {
+  it("is true when neither strict nor strictNullChecks is set", () => {
+    assert.equal(isStrictOff({ compilerOptions: {} }), true);
+  });
+
+  it("accepts strictNullChecks alone, which is the load-bearing half", () => {
+    assert.equal(isStrictOff({ compilerOptions: { strictNullChecks: true } }), false);
+  });
+
+  it("says nothing when there is no tsconfig to read", () => {
+    assert.equal(isStrictOff(null), false);
+  });
+});
+
+describe("sampleSourceFile", () => {
+  it("prefers TypeScript, because that is where the type-aware rules apply", () => {
+    const picked = sampleSourceFile([file("src/a.js"), file("src/b.ts")]);
+    assert.equal(picked?.path, "src/b.ts");
+  });
+
+  it("skips declarations and specs, whose config says nothing about the code", () => {
+    const picked = sampleSourceFile([file("src/a.d.ts"), file("test/b.ts"), file("src/c.ts")]);
+    assert.equal(picked?.path, "src/c.ts");
+  });
+
+  it("falls back rather than giving up when everything is excluded", () => {
+    assert.equal(sampleSourceFile([file("test/only.ts")])?.path, "test/only.ts");
+  });
+
+  it("returns null for an empty repo", () => {
+    assert.equal(sampleSourceFile([]), null);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,10 @@
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
     "noFallthroughCasesInSwitch": true,
+    // Not included by `strict`, and each measured at zero cost here before being switched on.
+    "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
     "verbatimModuleSyntax": true,
     "isolatedModules": true,
     // Imports are written with `.ts` extensions so `node --test test/*.ts` runs the sources


### PR DESCRIPTION
## Summary

A repo can have a config file, a strict preset and a green build while the rules that find real
bugs are silently off — and nothing reports it, because a rule that is off says nothing.

`diagnose` now asks the tools rather than reading the files:

- **`eslint --print-config <file>`** for 17 high-value rules, reporting `off` and `warn-only`
  separately.
- **`tsc --showConfig`** — resolved after every `extends` — for the 6 strictness flags that
  `strict: true` does **not** include.

## Items to Confirm / Review

1. **It found real gaps in this repo on the first run**: `max-params` off, and
   `exactOptionalPropertyTypes` / `noImplicitReturns` / `noPropertyAccessFromIndexSignature`
   missing. All four are now on and the 7 resulting type errors are fixed.

2. **Two measurement traps, both of which gave the wrong answer here before being caught:**
   - `tsc` colours its output, so `grep -c "error TS"` matches nothing and reports a clean run.
     Three flags measured "zero cost" that way; one actually had six errors. **`--pretty false` is
     required when counting.**
   - A flag must be measured by **enabling it in the tsconfig**, not by passing it on the command
     line. The two disagreed here.

3. **Why this matters beyond this PR:** type errors have **no** suppression mechanism —
   `--suppress-all` cannot touch them. A strictness flag has to be priced before it is switched on,
   or the owner gets a repo whose `typecheck` script fails with nothing able to grandfather it.
   That constraint shapes the auto-enable feature that comes next.

4. **`warn` is reported as a distinct state from `off`.** It enforces nothing either, but it is a
   deliberate stop on the way to `error` — and one that stays there forever unless counted.

5. Probes return `null` rather than throwing when the tool is absent. A repo without ESLint is the
   normal input here.

## Gate

`format:check`, `lint`, `typecheck`, `build`, **136** tests, `knip` clean. `diagnose` on this repo
now reports **no gaps**.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)