### PR TITLE
docs: 0.2.0 — the four layers, the log, and staleness

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Make an existing codebase one that can only get better",
-    "version": "0.1.0"
+    "version": "0.2.0"
   },
   "plugins": [
     {
@@ -15,8 +15,10 @@
         "repo": "isamu/ever-better"
       },
       "description": "Diagnose a repository, install the quality tooling it is missing, and pin a baseline that can only get better",
-      "version": "0.1.0",
-      "author": { "name": "isamu" },
+      "version": "0.2.0",
+      "author": {
+        "name": "isamu"
+      },
       "category": "development",
       "license": "MIT",
       "keywords": ["eslint", "code-quality", "refactoring", "technical-debt", "ratchet"]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ever-better",
   "description": "Diagnose a repository, install the quality tooling it is missing, and pin a baseline that can only get better",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "isamu",
     "url": "https://github.com/isamu"

--- a/README.ja.md
+++ b/README.ja.md
@@ -92,9 +92,18 @@ Node 20.11 以上。yarn / npm / pnpm / bun に対応（lockfile から自動判
 
 ### `bootstrap`
 
-そのリポジトリのパッケージマネージャで不足している devDependencies を導入し、階層構造を持つ flat ESLint 設定を生成し、CI が必要とする `lint` / `format` / `typecheck` / `test` スクリプトを追加し、3プラットフォームの GitHub Actions ワークフローを書きます。
+そのリポジトリのパッケージマネージャで不足している devDependencies を導入し、この手法が依存する**4つの層**を生成します。それぞれ、他の層には見えないものを見ます:
 
-既にある設定ファイルは決して上書きしません。`--dry-run` で計画だけを表示します。
+| 層 | ツール | 見えるもの |
+| --- | --- | --- |
+| 関数の大きさ・複雑度 | ESLint コアルール | 長い関数、深いネスト、分岐過多 |
+| 型と可読性 | SonarJS + `strictTypeChecked` | 危険な `any`、認知的複雑度 |
+| ファイル横断の重複 | jscpd → Code Scanning | linter には見えないコピペ |
+| デッドコード | knip | 誰も import しない export、孤立ファイル |
+
+あわせて CI が必要とする `lint` / `format` / `typecheck` / `test` / `knip` スクリプト、3プラットフォームのワークフロー、`.gitattributes`、`.prettierignore`、そして `dependabot.yml` を書きます。最後のものは、ever-better が見なくなった後もピン留めした action バージョンを最新に保つためです。
+
+既にある設定ファイルは決して上書きしません — そこに書かれた例外には、ファイルに書かれていない理由があるからです。唯一の例外は行ベースの `.prettierignore` で、これは追記します。`--dry-run` で計画だけを表示します。
 
 ### `freeze`
 
@@ -110,9 +119,19 @@ CI のゲート。抑制されていないエラーがある場合、または�
 
 免除されていた違反を直すと、その suppression は不要になります。`prune` がそれを回収し、直した分だけ天井を下げます。天井が下がる唯一の経路です。
 
+### `log`
+
+```bash
+ever-better log --kind drained  --rule max-depth "6件、うち1件は本物のバグ"
+ever-better log --kind deferred --rule max-lines "router.ts が1400行。分割はそれ自体がプロジェクト"
+ever-better log --kind issue    --rule no-floating-promises "#42 を起票 — 挙動は製品判断"
+```
+
+現在の commit を添えて記録します。効くのは `deferred` です。`QUALITY.md` の **Carried over** チェックリストに、見た時点の commit 付きで出ます。「router.ts は分割が必要」というメモは、400コミット後には*いつ真だったのか*が分からなければ役に立たないからです。
+
 ### `status`
 
-現在のフェーズ、残りの件数、そして残件数が**少ない**ルール — つまり最初に片付けるべきルール — を表示します。
+現在のフェーズ、残りの件数、そして残件数が**少ない**ルール — つまり最初に片付けるべきルール — を表示します。診断から30日超・50コミット超、あるいは記録した commit がこの履歴に無い（rebase / force-push）場合は、先頭に `STALE` 行が出ます。ratchet 自体は陳腐化しません（ESLint が現ツリーに対して維持するため）が、gap 一覧・ファイルサイズ・見送りメモは陳腐化します。
 
 ## 成果物
 
@@ -122,7 +141,7 @@ CI のゲート。抑制されていないエラーがある場合、または�
 | `.ever-better/state.json` | ever-better | する — 台帳 |
 | `QUALITY.md` | 台帳から描画 | する — 人間向けのビュー |
 
-`QUALITY.md` は毎回再生成されます。`<!-- ever-better:notes:start -->` マーカーの間に書いたものは保持されます。
+`QUALITY.md` は毎回再生成され、台帳から描画された4つのセクションを持ちます: フェーズをチェックボックスにし残件の少ないルールを子項目にした **Worklist**、意図的に見送ったリファクタリングの **Carried over**、**Ratchet** 表、そして **Work log**。`<!-- ever-better:notes:start -->` マーカーの間に書いたものは保持されます。
 
 ## Claude Code プラグイン
 

--- a/README.md
+++ b/README.md
@@ -118,11 +118,23 @@ diagnosis.
 
 ### `bootstrap`
 
-Installs the missing dev dependencies with the repo's own package manager, generates a tiered flat
-ESLint config, adds the `lint` / `format` / `typecheck` / `test` scripts CI needs, and writes a
-three-platform GitHub Actions workflow.
+Installs the missing dev dependencies with the repo's own package manager and generates the four
+layers the approach depends on, each covering what the others cannot see:
 
-It never overwrites a config that already exists. `--dry-run` prints the plan and touches nothing.
+| Layer | Tool | What it sees |
+| --- | --- | --- |
+| function size and complexity | ESLint core rules | long functions, deep nesting, too many branches |
+| types and readability | SonarJS + `strictTypeChecked` | unsafe `any`, cognitive complexity |
+| cross-file duplication | jscpd, into Code Scanning | copy-paste the linter cannot see |
+| dead code | knip | exports nobody imports, orphaned files |
+
+Plus the `lint` / `format` / `typecheck` / `test` / `knip` scripts CI needs, a three-platform
+workflow, `.gitattributes`, `.prettierignore`, and `dependabot.yml` so the pinned action versions
+stay current after ever-better has stopped looking.
+
+It never overwrites a config that already exists — the exceptions in it have reasons that are not
+in the file. The one exception is `.prettierignore`, which is line-based and so is appended to.
+`--dry-run` prints the plan and touches nothing.
 
 ### `freeze`
 
@@ -143,10 +155,26 @@ its ceiling. Add it to the workflow after `lint`.
 After you fix a grandfathered violation, its suppression is stale. `prune` reclaims it, lowering
 the ceiling by exactly what you fixed. This is the only way the ceiling comes down.
 
+### `log`
+
+```bash
+ever-better log --kind drained  --rule max-depth "6 violations, 1 real bug"
+ever-better log --kind deferred --rule max-lines "router.ts is 1400 lines; its own project"
+ever-better log --kind issue    --rule no-floating-promises "opened #42 — product decision"
+```
+
+Records what happened against the current commit. `deferred` is the one that earns its keep: it
+renders into a **Carried over** checklist in `QUALITY.md` with the commit it was seen at, because
+"router.ts needs splitting" is useless four hundred commits later unless a reader can tell when it
+was true.
+
 ### `status`
 
 Prints the current phase, the backlog, and the rules with the smallest remaining counts — which
-are the ones to drain first.
+are the ones to drain first. It leads with a `STALE` line when the diagnosis is more than thirty
+days old, fifty commits behind, or was taken on a commit no longer in this history (a rebase or
+force-push). The ratchet itself never goes stale — ESLint maintains it against the current tree —
+but the gap list, the file sizes and every deferred note do.
 
 ## Artifacts
 
@@ -156,8 +184,10 @@ are the ones to drain first.
 | `.ever-better/state.json` | ever-better | yes — the ledger |
 | `QUALITY.md` | rendered from the ledger | yes — the human view |
 
-`QUALITY.md` is regenerated on every run. Anything you write between the
-`<!-- ever-better:notes:start -->` markers survives.
+`QUALITY.md` is regenerated on every run and carries four sections rendered from the ledger: a
+**Worklist** of phases as checkboxes with the smallest remaining rules as sub-items, **Carried
+over** for refactors deliberately not made, the **Ratchet** table, and a **Work log**. Anything you
+write between the `<!-- ever-better:notes:start -->` markers survives.
 
 ## Claude Code plugin
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ever-better",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Diagnose a repository, install the quality tooling it is missing, and pin a baseline that can only get better.",
   "keywords": [
     "eslint",


### PR DESCRIPTION
## Summary

Docs and version bump. 0.1.0's README described a tool that installed ESLint; it now installs four
layers, keeps a worklist and a work log, and warns when its own diagnosis has gone stale.

Both READMEs updated. `package.json`, `plugin.json` and `marketplace.json` bumped to **0.2.0**.

## What changed since 0.1.0

- Vue / React / Next / Nuxt support, verified against fixtures running the real linter
- Errors and warnings separated — `--suppress-all` covers errors only, so warnings get their own ratchet
- `.gitattributes`, and the Windows spawn fix (ENOENT on the `.bin` shim)
- The `drain`, `dry` and `run` skills — the phases that actually clean up
- Worklist, Carried over, Work log, and the `log` command
- Stale-diagnosis warning: 30 days, 50 commits, or a commit no longer in this history
- **Effective-config probe**: `eslint --print-config` and `tsc --showConfig`, because a config file
  does not tell you what is enforced
- knip, jscpd and `dependabot.yml` generation; `strictTypeChecked`
- Action versions in one constant, pinned by a test against this repo's own workflows

## Items to Confirm / Review

Publishing 0.2.0 to npm right after this merges. Say if the version should be different — the
changes are additive and nothing published in 0.1.0 changed shape, so minor rather than major.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)