### PR TITLE
feat: turn on the strictness flags that cost nothing, price the rest

### DIFF
--- a/src/commands/bootstrap.ts
+++ b/src/commands/bootstrap.ts
@@ -12,6 +12,7 @@ import { gatherFacts } from "../facts.ts";
 import { headCommit } from "../git.ts";
 import { writeQualityFile } from "../qualityFile.ts";
 import { emptyState, readState, withDiagnosis, withPhase, writeState } from "../state.ts";
+import { applyStrictness } from "./strictness.ts";
 import { exec } from "../util/exec.ts";
 import type { PackageManager } from "../types.ts";
 
@@ -88,14 +89,25 @@ export const runBootstrap = async (options: BootstrapOptions): Promise<string> =
     prettierIgnore: await readIfPresent(path.join(options.cwd, PRETTIER_IGNORE_FILE)),
   });
 
-  if (actions.length === 0) return "Nothing to install or generate. Run `ever-better freeze` next.";
-
   const lines = actions.map((action) => `  ${describeAction(action)}`);
-  if (options.dryRun) return ["Would apply:", ...lines, "", "Re-run without --dry-run."].join("\n");
+  if (options.dryRun) {
+    const preview =
+      actions.length === 0 ? ["Nothing to install or generate."] : ["Would apply:", ...lines];
+    return [
+      ...preview,
+      "",
+      "Strictness is measured on a real run.",
+      "Re-run without --dry-run.",
+    ].join("\n");
+  }
 
   for (const action of actions) {
     await applyAction(options.cwd, diagnosis.packageManager, action);
   }
+
+  // After the plan, not before: TypeScript may only have just been installed, and there is
+  // nothing to measure against until it is.
+  const strictness = await applyStrictness(options.cwd, facts.sourceFiles);
 
   const after = diagnose(await gatherFacts(options.cwd));
   const previous = (await readState(options.cwd)) ?? emptyState();
@@ -103,5 +115,14 @@ export const runBootstrap = async (options: BootstrapOptions): Promise<string> =
   await writeState(options.cwd, state);
   await writeQualityFile(options.cwd, state);
 
-  return ["Applied:", ...lines, "", "Next: `ever-better freeze` to pin the baseline."].join("\n");
+  // Reported even when the plan was empty. A repo that already has every tool is the common case
+  // for an existing codebase, and returning early there skipped the tightening entirely.
+  return [
+    actions.length === 0 ? "Nothing to install or generate." : "Applied:",
+    ...lines,
+    "",
+    strictness.message,
+    "",
+    "Next: `ever-better freeze` to pin the baseline.",
+  ].join("\n");
 };

--- a/src/commands/strictness.ts
+++ b/src/commands/strictness.ts
@@ -1,0 +1,70 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { addCompilerOptions } from "../generate/tsconfigEdit.ts";
+import { findMissingStrictness, isStrictOff } from "../probe/effectiveTsconfig.ts";
+import { gatherProbes } from "../probe/gather.ts";
+import {
+  freeFlags,
+  measureStrictnessCosts,
+  pricedFlags,
+  type FlagCost,
+} from "../probe/tsconfigCost.ts";
+import type { SourceFile } from "../types.ts";
+
+export type StrictnessResult = {
+  applied: string[];
+  priced: FlagCost[];
+  message: string;
+};
+
+const TSCONFIG = "tsconfig.json";
+
+const COMMENT = "Enabled by ever-better after measuring each at zero new type errors.";
+
+const describePriced = (priced: readonly FlagCost[]): string[] =>
+  priced.map((cost) => `  ${cost.flag}: ${cost.errors ?? "?"} type errors — left off`);
+
+/**
+ * Turns on the strictness flags that cost nothing, and reports the price of the ones that do.
+ *
+ * The asymmetry with lint rules is the whole reason this is measured rather than just applied:
+ * `--suppress-all` grandfathers lint violations, and there is no equivalent for type errors. A
+ * flag that costs 500 errors would leave the owner with a `typecheck` script that fails and no way
+ * to stage the work.
+ */
+export const applyStrictness = async (
+  cwd: string,
+  sourceFiles: readonly SourceFile[],
+): Promise<StrictnessResult> => {
+  const probes = await gatherProbes(cwd, sourceFiles);
+  if (!probes.tsconfig) {
+    return { applied: [], priced: [], message: "No TypeScript config to tighten." };
+  }
+  if (isStrictOff(probes.tsconfig)) {
+    return {
+      applied: [],
+      priced: [],
+      message: "`strict` itself is off — turn that on first; everything else is moot until then.",
+    };
+  }
+
+  const off = findMissingStrictness(probes.tsconfig).map((entry) => entry.flag.name);
+  if (off.length === 0) return { applied: [], priced: [], message: "Strictness already maximal." };
+
+  const costs = await measureStrictnessCosts(cwd, off);
+  const free = freeFlags(costs);
+  const priced = pricedFlags(costs);
+
+  if (free.length > 0) {
+    const configPath = path.join(cwd, TSCONFIG);
+    const updated = addCompilerOptions(await readFile(configPath, "utf8"), free, COMMENT);
+    if (updated) await writeFile(configPath, updated, "utf8");
+  }
+
+  const lines = [
+    free.length > 0 ? `Enabled at zero cost: ${free.join(", ")}` : "Nothing was free to enable.",
+    ...(priced.length > 0 ? ["Priced and left off — each is a task, not a flag flip:"] : []),
+    ...describePriced(priced),
+  ];
+  return { applied: free, priced, message: lines.join("\n") };
+};

--- a/src/generate/tsconfigEdit.ts
+++ b/src/generate/tsconfigEdit.ts
@@ -1,0 +1,38 @@
+/**
+ * A tsconfig is very often JSONC — comments, trailing commas — so parsing and re-serialising it
+ * would silently delete the reasons somebody wrote down. This inserts lines after the
+ * `"compilerOptions": {` anchor instead, leaving every other byte alone, and returns null rather
+ * than guessing when the anchor is not there.
+ */
+const ANCHOR = /("compilerOptions"\s*:\s*\{)/;
+
+export const addCompilerOptions = (
+  source: string,
+  flags: readonly string[],
+  comment: string,
+): string | null => {
+  const wanted = flags.filter((flag) => !source.includes(`"${flag}"`));
+  if (wanted.length === 0) return null;
+  if (!ANCHOR.test(source)) return null;
+
+  const indent = innerIndent(source);
+  const lines = [
+    `${indent}// ${comment}`,
+    ...wanted.map((flag) => `${indent}"${flag}": true,`),
+  ].join("\n");
+  return source.replace(ANCHOR, `$1\n${lines}`);
+};
+
+/**
+ * The indentation INSIDE `compilerOptions`, which is one level deeper than the key itself. Taking
+ * the first indented line in the file instead finds the outer level, and the inserted flags then
+ * sit a level short of everything around them.
+ *
+ * Bounded to eight characters: `\s+` before a quote backtracks super-linearly on a pathological
+ * file.
+ */
+const innerIndent = (source: string): string => {
+  const match = /\n([ \t]{0,8})"compilerOptions"/.exec(source);
+  const outer = match?.[1] ?? "  ";
+  return outer + (outer.length > 0 ? outer : "  ");
+};

--- a/src/probe/tsconfigCost.ts
+++ b/src/probe/tsconfigCost.ts
@@ -1,0 +1,69 @@
+import { rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { exec } from "../util/exec.ts";
+import { STRICTNESS_FLAGS } from "./effectiveTsconfig.ts";
+
+export type FlagCost = {
+  flag: string;
+  /** Type errors the flag introduces. Null when tsc could not be run at all. */
+  errors: number | null;
+};
+
+const PROBE_CONFIG = "tsconfig.ever-better-probe.json";
+
+const countErrors = (output: string): number =>
+  output.split("\n").filter((line) => line.includes("error TS")).length;
+
+/**
+ * `--pretty false` is not optional. tsc colours its output by default, which puts escape codes
+ * between "error" and "TS1234" — so counting them without it silently returns zero, and a flag
+ * with six errors is reported as free. That happened here before it was caught.
+ */
+export const measureFlagCost = async (cwd: string, flag: string): Promise<number | null> => {
+  const configPath = path.join(cwd, PROBE_CONFIG);
+  const tsc = path.join(cwd, "node_modules", "typescript", "bin", "tsc");
+  try {
+    // Extending the real config is what makes this a measurement rather than a guess: a flag
+    // passed on the command line resolves differently from the same flag in the project.
+    await writeFile(
+      configPath,
+      `${JSON.stringify({ extends: "./tsconfig.json", compilerOptions: { [flag]: true } }, null, 2)}\n`,
+      "utf8",
+    );
+    const result = await exec(
+      process.execPath,
+      [tsc, "--noEmit", "--pretty", "false", "-p", PROBE_CONFIG],
+      cwd,
+    );
+    return countErrors(`${result.stdout}\n${result.stderr}`);
+  } catch {
+    return null;
+  } finally {
+    await rm(configPath, { force: true });
+  }
+};
+
+/** Prices every strictness flag that is currently off. Sequential — tsc is not cheap. */
+export const measureStrictnessCosts = async (
+  cwd: string,
+  offFlags: readonly string[],
+): Promise<FlagCost[]> => {
+  const costs: FlagCost[] = [];
+  for (const flag of offFlags) {
+    costs.push({ flag, errors: await measureFlagCost(cwd, flag) });
+  }
+  return costs;
+};
+
+export const allStrictnessFlags = (): string[] => STRICTNESS_FLAGS.map((flag) => flag.name);
+
+/**
+ * Only the free ones are applied. A strictness flag that costs anything breaks `typecheck` the
+ * moment it is written, and type errors have NO suppression mechanism — `--suppress-all` cannot
+ * touch them, so there is nothing to grandfather the damage with.
+ */
+export const freeFlags = (costs: readonly FlagCost[]): string[] =>
+  costs.filter((cost) => cost.errors === 0).map((cost) => cost.flag);
+
+export const pricedFlags = (costs: readonly FlagCost[]): FlagCost[] =>
+  costs.filter((cost) => cost.errors !== null && cost.errors > 0);

--- a/test/test_tsconfigEdit.ts
+++ b/test/test_tsconfigEdit.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { addCompilerOptions } from "../src/generate/tsconfigEdit.ts";
+
+const COMMENT = "measured at zero cost";
+
+describe("addCompilerOptions", () => {
+  it("inserts after the compilerOptions anchor", () => {
+    const source = '{\n  "compilerOptions": {\n    "strict": true\n  }\n}\n';
+    const updated = addCompilerOptions(source, ["noImplicitReturns"], COMMENT);
+    assert.match(updated ?? "", /"noImplicitReturns": true,/);
+    assert.match(updated ?? "", /"strict": true/);
+  });
+
+  it("preserves comments, because a tsconfig is usually JSONC", () => {
+    // Parsing and re-serialising would delete the reasons somebody wrote down.
+    const source = '{\n  // keep me\n  "compilerOptions": {\n    "strict": true\n  }\n}\n';
+    const updated = addCompilerOptions(source, ["noImplicitReturns"], COMMENT);
+    assert.match(updated ?? "", /\/\/ keep me/);
+  });
+
+  it("skips a flag the file already mentions", () => {
+    const source = '{\n  "compilerOptions": {\n    "noImplicitReturns": false\n  }\n}\n';
+    assert.equal(addCompilerOptions(source, ["noImplicitReturns"], COMMENT), null);
+  });
+
+  it("returns null rather than guessing when there is no anchor", () => {
+    assert.equal(addCompilerOptions('{\n  "files": []\n}\n', ["noImplicitReturns"], COMMENT), null);
+  });
+
+  it("indents to the level INSIDE compilerOptions, not the level of the key", () => {
+    // Taking the first indented line in the file finds the outer level, and the inserted flags
+    // then sit a level short of every option around them.
+    const two = '{\n  "compilerOptions": {\n    "strict": true\n  }\n}\n';
+    assert.match(
+      addCompilerOptions(two, ["noImplicitReturns"], COMMENT) ?? "",
+      /\n {4}"noImplicitReturns"/,
+    );
+
+    const four = '{\n    "compilerOptions": {\n        "strict": true\n    }\n}\n';
+    assert.match(
+      addCompilerOptions(four, ["noImplicitReturns"], COMMENT) ?? "",
+      /\n {8}"noImplicitReturns"/,
+    );
+  });
+
+  it("adds only the flags that are missing", () => {
+    const source = '{\n  "compilerOptions": {\n    "noImplicitReturns": true\n  }\n}\n';
+    const updated = addCompilerOptions(
+      source,
+      ["noImplicitReturns", "noImplicitOverride"],
+      COMMENT,
+    );
+    assert.match(updated ?? "", /"noImplicitOverride": true,/);
+    assert.equal((updated ?? "").match(/noImplicitReturns/g)?.length, 1);
+  });
+});


### PR DESCRIPTION
## Summary

`diagnose` reported which flags `strict: true` does not include; `bootstrap` did nothing about
them. It now measures each and applies the free ones.

Verified on a fixture: **5 flags enabled at zero cost, `noUncheckedIndexedAccess` priced at 1 error
and left off**, hand-written comments preserved, `tsc --noEmit` still green afterwards.

## Items to Confirm / Review

1. **Measured, not applied — and the asymmetry with lint is the reason.** `--suppress-all`
   grandfathers lint violations; there is **no equivalent for type errors**. A flag costing 500
   errors leaves the owner with a failing `typecheck` and no way to stage the work. Priced flags are
   reported with their count and left off: each is a task, not a flag flip.

2. **Two measurement rules, both of which gave a wrong answer here first:**
   - **`--pretty false`.** tsc colours its output, putting escape codes between "error" and
     "TS1234", so counting without it returns zero and a six-error flag reads as free.
   - **Extend the real tsconfig in a temporary probe file**, never pass the flag on the command
     line. The two resolve differently.

3. **The tsconfig is edited by text insertion after the `"compilerOptions": {` anchor**, not parsed
   and re-serialised. A tsconfig is usually JSONC and a round trip would delete the comments
   explaining why the other options are there. It returns null rather than guessing when the anchor
   is absent, and matches the indentation already inside the block.

4. **Second bug, found while verifying:** `bootstrap` returned early when the plan was empty, so a
   repository that already had every tool — the common case for an existing codebase — was never
   tightened at all.

## Gate

`format:check`, `lint`, `typecheck`, `build`, **149** tests.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)