### PR TITLE
feat: strengthen an ESLint config the repository already wrote

### DIFF
--- a/src/commands/bootstrap.ts
+++ b/src/commands/bootstrap.ts
@@ -12,6 +12,7 @@ import { gatherFacts } from "../facts.ts";
 import { headCommit } from "../git.ts";
 import { writeQualityFile } from "../qualityFile.ts";
 import { emptyState, readState, withDiagnosis, withPhase, writeState } from "../state.ts";
+import { strengthenEslintConfig } from "./strengthen.ts";
 import { applyStrictness } from "./strictness.ts";
 import { exec } from "../util/exec.ts";
 import type { PackageManager } from "../types.ts";
@@ -109,6 +110,13 @@ export const runBootstrap = async (options: BootstrapOptions): Promise<string> =
   // nothing to measure against until it is.
   const strictness = await applyStrictness(options.cwd, facts.sourceFiles);
 
+  // Only meaningful when the repo brought its own config: a generated one already has every tier.
+  const strengthened = await strengthenEslintConfig(
+    options.cwd,
+    facts.rootEntries,
+    facts.sourceFiles,
+  );
+
   const after = diagnose(await gatherFacts(options.cwd));
   const previous = (await readState(options.cwd)) ?? emptyState();
   const state = withPhase(withDiagnosis(previous, after, await headCommit(options.cwd)), "freeze");
@@ -122,6 +130,8 @@ export const runBootstrap = async (options: BootstrapOptions): Promise<string> =
     ...lines,
     "",
     strictness.message,
+    "",
+    strengthened.message,
     "",
     "Next: `ever-better freeze` to pin the baseline.",
   ].join("\n");

--- a/src/commands/strengthen.ts
+++ b/src/commands/strengthen.ts
@@ -1,0 +1,133 @@
+import { copyFile, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { canLint, printConfig } from "../eslintRunner.ts";
+import { appendConfigBlocks, renderRuleBlock } from "../generate/eslintAppend.ts";
+import { findWeakRules, type RuleVerdict } from "../probe/effectiveRules.ts";
+import { sampleSourceFile } from "../probe/gather.ts";
+import type { SourceFile } from "../types.ts";
+
+export const BACKUP_SUFFIX = ".ever-better-backup";
+
+const CONFIG_NAMES = [
+  "eslint.config.js",
+  "eslint.config.mjs",
+  "eslint.config.cjs",
+  "eslint.config.ts",
+];
+
+const findConfig = (rootEntries: readonly string[]): string | null =>
+  CONFIG_NAMES.find((name) => rootEntries.includes(name)) ?? null;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const pluginNames = (plugins: unknown): string[] => {
+  if (Array.isArray(plugins)) return plugins.filter((name) => typeof name === "string");
+  return Object.keys(isRecord(plugins) ? plugins : {});
+};
+
+/**
+ * A rule from a plugin the config never registered cannot be set: ESLint refuses the whole file
+ * with "Could not find plugin". The printed config lists what is actually loaded, so this is the
+ * difference between strengthening a config and breaking it.
+ *
+ * It lists them as `name:package@version`, not as bare names — matching the whole string finds
+ * nothing, and every plugin rule is then silently skipped. That reads as "the config was already
+ * fine" rather than as a bug.
+ */
+const loadedPlugins = (printed: Record<string, unknown> | null): string[] =>
+  pluginNames(printed?.["plugins"]).map((name) => name.split(":")[0] ?? name);
+
+/**
+ * Type-aware rules need `project` or `projectService`. Setting one without it makes ESLint fatal
+ * on every file — a strengthened config that cannot lint anything is worse than a weak one.
+ */
+const hasTypeInformation = (printed: Record<string, unknown> | null): boolean => {
+  const options = printed?.["parserOptions"];
+  if (!isRecord(options)) return false;
+  return Boolean(options["project"]) || Boolean(options["projectService"]);
+};
+
+const isSettable = (rule: string, printed: Record<string, unknown> | null): boolean => {
+  const slash = rule.indexOf("/");
+  if (slash < 0) return true;
+  return loadedPlugins(printed).includes(rule.slice(0, slash));
+};
+
+export type StrengthenResult = {
+  enabled: string[];
+  skipped: string[];
+  message: string;
+};
+
+const nothing = (message: string): StrengthenResult => ({ enabled: [], skipped: [], message });
+
+const settableRules = (weak: readonly RuleVerdict[], printed: Record<string, unknown> | null) => {
+  const typed = hasTypeInformation(printed);
+  return weak.filter(
+    (verdict) =>
+      isSettable(verdict.rule.name, printed) && (typed || verdict.rule.typeAware !== true),
+  );
+};
+
+/**
+ * Adds the missing high-value rules to a config the repository already wrote.
+ *
+ * Backed up first, then verified by loading the result — a config this tool cannot parse is a
+ * config it must not silently mangle, and "ESLint still runs" is the only check that actually
+ * proves the edit was valid. On any doubt the backup goes back.
+ */
+export const strengthenEslintConfig = async (
+  cwd: string,
+  rootEntries: readonly string[],
+  sourceFiles: readonly SourceFile[],
+): Promise<StrengthenResult> => {
+  const configName = findConfig(rootEntries);
+  if (!configName) return nothing("No flat ESLint config to strengthen.");
+
+  const sample = sampleSourceFile(sourceFiles);
+  if (!sample) return nothing("No source file to measure the config against.");
+
+  const before = await printConfig(cwd, sample.path);
+  const weak = settableRules(findWeakRules(before), before);
+  if (weak.length === 0) return nothing("Every high-value rule is already enforcing.");
+
+  const configPath = path.join(cwd, configName);
+  const backupPath = `${configPath}${BACKUP_SUFFIX}`;
+  const original = await readFile(configPath, "utf8");
+  const block = renderRuleBlock(
+    weak.map((verdict) => ({ name: verdict.rule.name, setting: verdict.rule.setting })),
+    [
+      "Added by ever-better. Flat config is an array and later entries win, so this",
+      "block overrides whatever came before it. Everything above is untouched.",
+    ],
+  );
+  const updated = appendConfigBlocks(original, block);
+  if (!updated) {
+    return nothing(`Could not find where ${configName} ends — left it alone. Add these by hand.`);
+  }
+
+  await copyFile(configPath, backupPath);
+  await writeFile(configPath, updated, "utf8");
+
+  // Verified by LINTING, not by printing the config: printing resolves rules without loading them,
+  // so a rule needing a type program prints happily and then makes every real run fatal.
+  if (!(await canLint(cwd, sample.path))) {
+    await copyFile(backupPath, configPath);
+    await rm(backupPath, { force: true });
+    return nothing(`Editing ${configName} stopped ESLint running — restored, nothing changed.`);
+  }
+
+  const names = weak.map((verdict) => verdict.rule.name);
+  return {
+    enabled: names,
+    skipped: findWeakRules(before)
+      .filter((verdict) => !names.includes(verdict.rule.name))
+      .map((verdict) => verdict.rule.name),
+    message: [
+      `Strengthened ${configName}: ${names.length} rules now enforcing.`,
+      `  ${names.join(", ")}`,
+      `Backup at ${configName}${BACKUP_SUFFIX} — delete it once the diff looks right.`,
+    ].join("\n"),
+  };
+};

--- a/src/eslintRunner.ts
+++ b/src/eslintRunner.ts
@@ -145,6 +145,25 @@ export const printConfig = async (
   }
 };
 
+/**
+ * Does ESLint still work? `--print-config` answers a different question — it resolves the config
+ * without ever loading a rule, so a rule that needs a type program prints happily and then makes
+ * every real run fatal. Only linting something proves the config is usable.
+ */
+export const canLint = async (cwd: string, filePath: string): Promise<boolean> => {
+  const eslint = await findEslint(cwd);
+  if (!eslint) return false;
+  try {
+    const result = await exec(eslint.command, [...eslint.prefixArgs, filePath], cwd, {
+      shell: eslint.shell,
+    });
+    // 0 = clean, 1 = violations found. Both mean the config loaded and the rules ran.
+    return result.code < FATAL_EXIT_CODE;
+  } catch {
+    return false;
+  }
+};
+
 /** Drops suppressions for violations that no longer exist, which is how the ceiling comes down. */
 export const pruneSuppressions = async (cwd: string): Promise<void> => {
   await runEslint(cwd, [".", "--prune-suppressions"], "eslint --prune-suppressions");

--- a/src/generate/eslintAppend.ts
+++ b/src/generate/eslintAppend.ts
@@ -10,14 +10,31 @@
 // The whole trailing run of closers, because the INNERMOST one closes the config list. Taking the
 // last instead puts the appended block outside the array — for `defineConfig([...])` that makes it
 // a second argument, which is silently not a config at all.
-const CLOSERS = /[\])]+\s*;?\s*$/;
+const CLOSER_CHARS = new Set(["]", ")"]);
+
+/** Index of the innermost closer in the trailing run, or -1 when the file does not end in one. */
+const findClosersStart = (source: string): number => {
+  let end = source.length;
+  while (end > 0 && /\s/.test(source[end - 1] ?? "")) end -= 1;
+  if (source[end - 1] === ";") end -= 1;
+  while (end > 0 && /\s/.test(source[end - 1] ?? "")) end -= 1;
+
+  let start = end;
+  while (start > 0 && CLOSER_CHARS.has(source[start - 1] ?? "")) start -= 1;
+  return start === end ? -1 : start;
+};
+
+const trimTrailingSpace = (text: string): string => {
+  let end = text.length;
+  while (end > 0 && /\s/.test(text[end - 1] ?? "")) end -= 1;
+  return text.slice(0, end);
+};
 
 export const appendConfigBlocks = (source: string, blocks: readonly string[]): string | null => {
   if (blocks.length === 0) return null;
-  const match = CLOSERS.exec(source);
-  if (!match) return null;
-  const cutAt = match.index;
-  const head = source.slice(0, cutAt).replace(/\s*$/, "");
+  const cutAt = findClosersStart(source);
+  if (cutAt < 0) return null;
+  const head = trimTrailingSpace(source.slice(0, cutAt));
   const separator = head.endsWith(",") ? "" : ",";
   return `${head}${separator}\n${blocks.join("\n")}\n${source.slice(cutAt)}`;
 };

--- a/src/generate/eslintAppend.ts
+++ b/src/generate/eslintAppend.ts
@@ -1,0 +1,38 @@
+/**
+ * Appends rule blocks to a flat config the repo already wrote.
+ *
+ * Flat config is an array and later entries win, so appending is semantically well defined. The
+ * textual insertion point is the risk: a config may end `];`, `);` or `]);` depending on whether
+ * it was written by hand, by `tseslint.config()` or by `defineConfig()`. This finds the final
+ * closer and returns null rather than guessing when it cannot — the caller keeps a backup and
+ * verifies the result by loading it, so a bad edit is caught rather than shipped.
+ */
+const CLOSER = /([\])])\s*;?\s*$/;
+
+export const appendConfigBlocks = (source: string, blocks: readonly string[]): string | null => {
+  if (blocks.length === 0) return null;
+  const match = CLOSER.exec(source);
+  if (!match) return null;
+  const cutAt = source.lastIndexOf(match[1] ?? "");
+  if (cutAt < 0) return null;
+  const head = source.slice(0, cutAt).replace(/\s*$/, "");
+  const separator = head.endsWith(",") ? "" : ",";
+  return `${head}${separator}\n${blocks.join("\n")}\n${source.slice(cutAt)}`;
+};
+
+export type RuleEntry = {
+  name: string;
+  setting: string;
+};
+
+export const renderRuleBlock = (
+  entries: readonly RuleEntry[],
+  comment: readonly string[],
+): string[] => [
+  "  {",
+  ...comment.map((line) => `    // ${line}`),
+  "    rules: {",
+  ...entries.map((entry) => `      "${entry.name}": ${entry.setting},`),
+  "    },",
+  "  },",
+];

--- a/src/generate/eslintAppend.ts
+++ b/src/generate/eslintAppend.ts
@@ -7,14 +7,16 @@
  * closer and returns null rather than guessing when it cannot — the caller keeps a backup and
  * verifies the result by loading it, so a bad edit is caught rather than shipped.
  */
-const CLOSER = /([\])])\s*;?\s*$/;
+// The whole trailing run of closers, because the INNERMOST one closes the config list. Taking the
+// last instead puts the appended block outside the array — for `defineConfig([...])` that makes it
+// a second argument, which is silently not a config at all.
+const CLOSERS = /[\])]+\s*;?\s*$/;
 
 export const appendConfigBlocks = (source: string, blocks: readonly string[]): string | null => {
   if (blocks.length === 0) return null;
-  const match = CLOSER.exec(source);
+  const match = CLOSERS.exec(source);
   if (!match) return null;
-  const cutAt = source.lastIndexOf(match[1] ?? "");
-  if (cutAt < 0) return null;
+  const cutAt = match.index;
   const head = source.slice(0, cutAt).replace(/\s*$/, "");
   const separator = head.endsWith(",") ? "" : ",";
   return `${head}${separator}\n${blocks.join("\n")}\n${source.slice(cutAt)}`;

--- a/src/probe/effectiveRules.ts
+++ b/src/probe/effectiveRules.ts
@@ -13,6 +13,10 @@ export type PrintedConfig = {
 export type HighValueRule = {
   name: string;
   why: string;
+  /** What to set it to when strengthening a config that already exists. */
+  setting: string;
+  /** Needs a type program. Setting one without `project`/`projectService` makes ESLint fatal. */
+  typeAware?: boolean;
 };
 
 /**
@@ -21,41 +25,87 @@ export type HighValueRule = {
  * was already strict.
  */
 export const HIGH_VALUE_RULES: readonly HighValueRule[] = [
-  { name: "@typescript-eslint/no-explicit-any", why: "`any` switches off every other type rule" },
+  {
+    name: "@typescript-eslint/no-explicit-any",
+    why: "`any` switches off every other type rule",
+    setting: '"error"',
+  },
   {
     name: "@typescript-eslint/no-unsafe-assignment",
     why: "unvalidated JSON and API responses flow in as `any`",
+    setting: '"error"',
+    typeAware: true,
   },
-  { name: "@typescript-eslint/no-unsafe-member-access", why: "reads through an unchecked `any`" },
-  { name: "@typescript-eslint/no-unsafe-call", why: "calls through an unchecked `any`" },
-  { name: "@typescript-eslint/no-unsafe-return", why: "leaks `any` back out to callers" },
-  { name: "@typescript-eslint/no-unsafe-argument", why: "passes `any` into a typed parameter" },
-  { name: "@typescript-eslint/no-floating-promises", why: "a forgotten await fails silently" },
+  {
+    name: "@typescript-eslint/no-unsafe-member-access",
+    why: "reads through an unchecked `any`",
+    setting: '"error"',
+    typeAware: true,
+  },
+  {
+    name: "@typescript-eslint/no-unsafe-call",
+    why: "calls through an unchecked `any`",
+    setting: '"error"',
+    typeAware: true,
+  },
+  {
+    name: "@typescript-eslint/no-unsafe-return",
+    why: "leaks `any` back out to callers",
+    setting: '"error"',
+    typeAware: true,
+  },
+  {
+    name: "@typescript-eslint/no-unsafe-argument",
+    why: "passes `any` into a typed parameter",
+    setting: '"error"',
+    typeAware: true,
+  },
+  {
+    name: "@typescript-eslint/no-floating-promises",
+    why: "a forgotten await fails silently",
+    setting: '"error"',
+    typeAware: true,
+  },
   {
     name: "@typescript-eslint/no-misused-promises",
     why: "an async callback where none is awaited",
+    setting: '"error"',
+    typeAware: true,
   },
-  { name: "@typescript-eslint/await-thenable", why: "awaiting a non-promise hides a missing call" },
+  {
+    name: "@typescript-eslint/await-thenable",
+    why: "awaiting a non-promise hides a missing call",
+    setting: '"error"',
+    typeAware: true,
+  },
   {
     name: "@typescript-eslint/consistent-type-assertions",
     why: "`as` asserts what the compiler could not check; it lives in the stylistic preset, not strict",
+    setting: '["error", { assertionStyle: "never" }]',
   },
-  { name: "@typescript-eslint/no-non-null-assertion", why: "`!` is an unchecked claim" },
+  {
+    name: "@typescript-eslint/no-non-null-assertion",
+    why: "`!` is an unchecked claim",
+    setting: '"error"',
+  },
   {
     name: "sonarjs/cognitive-complexity",
     why: "how hard a function is for a human, not a machine",
+    setting: '["error", 15]',
   },
   {
     name: "max-lines-per-function",
     why: "the guard that keeps a function comprehensible at a glance",
+    setting: '["error", { max: 60, skipBlankLines: true, skipComments: true }]',
   },
   {
     name: "max-lines",
     why: "per-file size; the per-function guards pass while a file reaches 2000 lines",
+    setting: '["error", { max: 600, skipBlankLines: true, skipComments: true }]',
   },
-  { name: "complexity", why: "branch count" },
-  { name: "max-depth", why: "nesting" },
-  { name: "max-params", why: "argument count" },
+  { name: "complexity", why: "branch count", setting: '["error", 20]' },
+  { name: "max-depth", why: "nesting", setting: '["error", 4]' },
+  { name: "max-params", why: "argument count", setting: '["error", 6]' },
 ];
 
 const OFF_LEVELS = new Set<number | string>([0, "off"]);

--- a/test/test_eslintAppend.ts
+++ b/test/test_eslintAppend.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { appendConfigBlocks, renderRuleBlock } from "../src/generate/eslintAppend.ts";
+
+const BLOCK = renderRuleBlock([{ name: "max-depth", setting: '["error", 4]' }], ["measured"]);
+
+describe("appendConfigBlocks", () => {
+  it("appends inside a plain array export", () => {
+    const updated = appendConfigBlocks("export default [\n  js.configs.recommended,\n];\n", BLOCK);
+    assert.match(updated ?? "", /max-depth/);
+    assert.match(updated ?? "", /\];\s*$/);
+  });
+
+  it("appends inside tseslint.config(...)", () => {
+    const source = "export default tseslint.config(\n  js.configs.recommended,\n);\n";
+    const updated = appendConfigBlocks(source, BLOCK);
+    assert.match(updated ?? "", /max-depth/);
+    assert.match(updated ?? "", /\);\s*$/);
+  });
+
+  it("appends inside defineConfig([...])", () => {
+    const source = "export default defineConfig([\n  base,\n]);\n";
+    const updated = appendConfigBlocks(source, BLOCK);
+    assert.match(updated ?? "", /max-depth/);
+    assert.match(updated ?? "", /\]\);\s*$/);
+  });
+
+  it("does not double the separating comma", () => {
+    const updated = appendConfigBlocks("export default [\n  base,\n];\n", BLOCK) ?? "";
+    assert.ok(!updated.includes(",,"));
+  });
+
+  it("adds the comma when the last entry has none", () => {
+    const updated = appendConfigBlocks("export default [\n  base\n];\n", BLOCK) ?? "";
+    assert.match(updated, /base,\n/);
+  });
+
+  it("keeps everything that was already there", () => {
+    const source = "// a reason someone wrote down\nexport default [\n  base,\n];\n";
+    assert.match(appendConfigBlocks(source, BLOCK) ?? "", /a reason someone wrote down/);
+  });
+
+  it("returns null rather than guessing when there is no closer", () => {
+    assert.equal(appendConfigBlocks("export default base", BLOCK), null);
+  });
+
+  it("returns null when there is nothing to add", () => {
+    assert.equal(appendConfigBlocks("export default [];\n", []), null);
+  });
+});
+
+describe("renderRuleBlock", () => {
+  it("writes each rule with its setting", () => {
+    const block = renderRuleBlock(
+      [
+        { name: "complexity", setting: '["error", 20]' },
+        { name: "@typescript-eslint/no-explicit-any", setting: '"error"' },
+      ],
+      ["why"],
+    ).join("\n");
+    assert.match(block, /"complexity": \["error", 20\],/);
+    assert.match(block, /"@typescript-eslint\/no-explicit-any": "error",/);
+    assert.match(block, /\/\/ why/);
+  });
+});

--- a/test/test_eslintAppend.ts
+++ b/test/test_eslintAppend.ts
@@ -18,11 +18,13 @@ describe("appendConfigBlocks", () => {
     assert.match(updated ?? "", /\);\s*$/);
   });
 
-  it("appends inside defineConfig([...])", () => {
+  it("appends INSIDE the array of defineConfig([...]), not after it", () => {
+    // Taking the last closer instead of the innermost makes the block a second argument to
+    // defineConfig — silently not a config at all.
     const source = "export default defineConfig([\n  base,\n]);\n";
-    const updated = appendConfigBlocks(source, BLOCK);
-    assert.match(updated ?? "", /max-depth/);
-    assert.match(updated ?? "", /\]\);\s*$/);
+    const updated = appendConfigBlocks(source, BLOCK) ?? "";
+    assert.match(updated, /\]\);\s*$/);
+    assert.ok(updated.indexOf("max-depth") < updated.indexOf("]);"));
   });
 
   it("does not double the separating comma", () => {


### PR DESCRIPTION
## Summary

A repo with its own `eslint.config.js` gained **no rules at all** — the probe reported which were
off and nothing acted on it. That is most real repositories.

`bootstrap` now appends one block to the existing config. Backed up first, and the result is
verified by **linting**; on failure the backup goes back and nothing changed.

Verified on a fixture with a hand-written config: **7 rules added**, comments and structure intact,
`eslint .` exits 1 (violations found — the config loaded and the rules ran).

## Items to Confirm / Review

1. **Backup, then verify by linting — not by `--print-config`.** Printing resolves the config
   without ever loading a rule, so a rule needing a type program prints happily and then makes every
   real run fatal. `canLint` runs ESLint on one file and accepts exit 0 or 1; anything higher
   restores the backup.

2. **Two rules about what may be added, both found by running it:**
   - **Only rules whose plugin is already registered.** `--print-config` lists plugins as
     `name:package@version`, so matching the whole string finds nothing and every plugin rule is
     silently skipped — which reads as "the config was already fine" rather than as a bug. On the
     fixture that was the difference between **5 rules and 7**.
   - **No type-aware rules without `project`/`projectService`.** A strengthened config that cannot
     lint anything is worse than a weak one.

3. **The insertion point.** Flat config ends `];`, `);` or `]);`. Taking the *last* closer put the
   block between `]` and `)` for `defineConfig([...])` — a second argument, silently not a config.
   The innermost closer in the trailing run is the right one; three shapes are covered by tests.

4. **The backup is left behind on success** (`eslint.config.js.ever-better-backup`) for the user to
   delete once the diff looks right. Say if it should be removed automatically instead.

## Also in this branch

`tsconfig` strictness (#11 from the audit) shipped in #18; this branch adds the ESLint half.

## Gate

`format:check`, `lint`, `typecheck`, `build`, **158** tests.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)