### PR TITLE
feat: the security and readability tiers, and why no import plugin

### DIFF
--- a/src/bootstrapPlan.ts
+++ b/src/bootstrapPlan.ts
@@ -44,8 +44,9 @@ const installed = (packageJson: PackageJson | null): Set<string> =>
 const missingPackages = (options: BootstrapPlanOptions): string[] => {
   const have = installed(options.packageJson);
   const { framework, language, tooling } = options.diagnosis;
-  const wanted = [...eslintPackagesFor(framework), "prettier"];
-  if (language !== "javascript") {
+  const typed = language !== "javascript";
+  const wanted = [...eslintPackagesFor(framework, options.diagnosis.runtime), "prettier"];
+  if (typed) {
     wanted.push("typescript", "@types/node");
     // `tsc` cannot read an SFC at all, so a Vue repo typechecking with it silently skips every
     // component. vue-tsc is what the typecheck script will call.

--- a/src/generate/eslintConfig.ts
+++ b/src/generate/eslintConfig.ts
@@ -21,8 +21,30 @@ const BASE_PACKAGES = [
   "eslint-config-prettier",
 ];
 
-export const eslintPackagesFor = (framework: Framework): string[] => [
+/*
+ * Import-cycle detection is deliberately absent, and it took three attempts to establish why:
+ *
+ *   - `eslint-plugin-import` peers at eslint ^9, so it cannot be installed beside ESLint 10.
+ *   - `eslint-plugin-import-x` does support 10, but `no-cycle` needs a resolver that understands
+ *     TypeScript. `flatConfigs.typescript` names `eslint-import-resolver-typescript`, whose
+ *     optional peer drags `eslint-plugin-import` back in and fails the whole install.
+ *   - import-x's own `createNodeResolver`, told about `.ts`, loads without error and then reports
+ *     nothing at all on a genuine two-file cycle. Measured, not assumed.
+ *
+ * An enabled rule that silently finds nothing is the worst of the three: it reads as proof the
+ * codebase has no cycles. Revisit when the import ecosystem has caught up with ESLint 10.
+ */
+
+/**
+ * The security plugin only where its rules can apply: everything it looks for — child processes,
+ * non-literal fs paths, unsafe regexes — is Node-side. On a browser-only bundle it is noise.
+ */
+const securityPackages = (runtime: Runtime): string[] =>
+  runtime === "browser" ? [] : ["eslint-plugin-security"];
+
+export const eslintPackagesFor = (framework: Framework, runtime: Runtime = "node"): string[] => [
   ...BASE_PACKAGES,
+  ...securityPackages(runtime),
   ...frameworkParts(framework, true).packages,
 ];
 
@@ -86,6 +108,24 @@ const typedBlock = (options: EslintConfigOptions): string[] => {
     "  },",
   ];
 };
+
+/**
+ * Rules that keep the code readable to whoever arrives next, rather than correct. `id-length`
+ * carries exceptions because a loop counter and a discarded binding are not the problem it is
+ * aimed at — a variable called `d` holding a customer record is.
+ */
+const readabilityBlock = (): string[] => [
+  "  {",
+  "    rules: {",
+  "      // A loop counter and a discarded binding are not what this is aimed at; a variable called",
+  "      // `d` holding a customer record is. `js`, `fs`, `os` are the conventional module aliases.",
+  '      "id-length": [',
+  '        "error",',
+  '        { min: 3, exceptions: ["_", "i", "j", "k", "id", "ok", "to", "up", "js", "fs", "os"] },',
+  "      ],",
+  "    },",
+  "  },",
+];
 
 const limitsBlock = (options: EslintConfigOptions): string[] => [
   "  {",
@@ -154,11 +194,18 @@ const testBlock = (options: EslintConfigOptions): string[] => [
   "  },",
 ];
 
+const securityImport = (runtime: Runtime): string[] =>
+  runtime === "browser" ? [] : ['import security from "eslint-plugin-security";'];
+
+const securityBlock = (runtime: Runtime): string[] =>
+  runtime === "browser" ? [] : ["  security.configs.recommended,"];
+
 export const renderEslintConfig = (options: EslintConfigOptions): string => {
   const framework = frameworkParts(options.framework, options.typed);
   return [
     ...HEADER,
     ...BASE_IMPORTS,
+    ...securityImport(options.runtime),
     ...framework.imports,
     "",
     "export default tseslint.config(",
@@ -167,6 +214,7 @@ export const renderEslintConfig = (options: EslintConfigOptions): string => {
     "  js.configs.recommended,",
     ...typedBlock(options),
     "  sonarjs.configs.recommended,",
+    ...securityBlock(options.runtime),
     ...framework.configs,
     "  prettier,",
     "",
@@ -174,6 +222,7 @@ export const renderEslintConfig = (options: EslintConfigOptions): string => {
     "",
     ...strictnessBlock(options),
     ...limitsBlock(options),
+    ...readabilityBlock(),
     ...testBlock(options),
     ...configFileBlock(options),
     ");",

--- a/test/test_diagnose.ts
+++ b/test/test_diagnose.ts
@@ -172,6 +172,8 @@ describe("planBootstrap", () => {
           "typescript-eslint": "^8",
           "eslint-plugin-sonarjs": "^4",
           "eslint-config-prettier": "^10",
+          "eslint-plugin-import-x": "^4",
+          "eslint-plugin-security": "^4",
           knip: "^6",
           prettier: "^3",
           vitest: "^4",

--- a/test/test_render.ts
+++ b/test/test_render.ts
@@ -190,3 +190,41 @@ describe("QUALITY.md", () => {
     assert.equal(renderQuality(frozen(), "n", FRESH), renderQuality(frozen(), "n", FRESH));
   });
 });
+
+describe("renderEslintConfig — readability and security tiers", () => {
+  const opts = {
+    typed: true,
+    fileLineLimit: 600,
+    testGlob: "test/**",
+    testRunner: "vitest" as const,
+    framework: "none" as const,
+    runtime: "node" as const,
+  };
+
+  it("ships no import plugin at all", () => {
+    // Measured, not assumed: eslint-plugin-import caps at eslint ^9; the TypeScript resolver drags
+    // it back in and fails the install; and import-x's own resolver reports nothing on a real
+    // two-file cycle. An enabled rule that silently finds nothing reads as proof of no cycles.
+    const config = renderEslintConfig(opts);
+    assert.ok(!config.includes("import-x"));
+    assert.ok(!config.includes("no-cycle"));
+  });
+
+  it("gives id-length exceptions, because a loop counter is not the problem", () => {
+    const config = renderEslintConfig(opts);
+    assert.match(config, /"id-length"/);
+    assert.match(config, /min: 3, exceptions:/);
+    // `js` is the conventional alias for @eslint/js and appears in this very file.
+    assert.match(config, /"js"/);
+  });
+
+  it("adds the security tier for Node-side code", () => {
+    assert.match(renderEslintConfig(opts), /security\.configs\.recommended/);
+  });
+
+  it("leaves the security tier out of a browser-only bundle", () => {
+    // Everything it looks for — child processes, non-literal fs paths — is Node-side.
+    const browser = renderEslintConfig({ ...opts, runtime: "browser" });
+    assert.ok(!browser.includes("eslint-plugin-security"));
+  });
+});


### PR DESCRIPTION
## Summary

Two of the three remaining rule groups from the first article ship. The third does not, and the
reason is the interesting part.

- **`eslint-plugin-security`**, wherever its rules can apply. Everything it looks for — child
  processes, non-literal fs paths, unsafe regexes — is Node-side, so a browser-only bundle gets
  nothing but noise; gated on the detected runtime.
- **`id-length`** with exceptions. A loop counter and a discarded binding are not what it is aimed
  at; a variable called `d` holding a customer record is.

## Items to Confirm / Review

**Import-cycle detection is deliberately absent.** Three attempts, each measured:

1. `eslint-plugin-import` peers at eslint `^9` — cannot be installed beside ESLint 10 at all.
2. `eslint-plugin-import-x` does support 10, but `no-cycle` needs a TypeScript-aware resolver.
   `flatConfigs.typescript` names `eslint-import-resolver-typescript`, whose **optional** peer drags
   `eslint-plugin-import` back in and fails the entire install — bootstrap left the fixture with no
   linter.
3. import-x's own `createNodeResolver`, told about `.ts`, loads cleanly and then reports **nothing**
   on a genuine two-file cycle. Verified with `--print-config` (rule on, severity 2, resolver
   present) and a direct `--rule` run.

The third is the worst of the three: an enabled rule finding nothing reads as proof the codebase has
no cycles. The reasoning is in a comment beside the code and pinned by a test, so a later attempt
starts from what was already tried.

Worth revisiting when the import ecosystem catches up with ESLint 10.

## Also

`id-length` initially fired on the generated config's own `import js from "@eslint/js"` — noise
shipped to every user. `js`, `fs` and `os` are exempted.

## Gate

`format:check`, `lint`, `typecheck`, `build`, **162** tests. Verified on a fixture: the security
plugin installs and loads, `id-length` reports, and the generated config lints clean of itself.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)