### PR TITLE
feat: emit-diff — prove a type-only refactor changed nothing

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -129,6 +129,17 @@ ever-better log --kind issue    --rule no-floating-promises "#42 を起票 — �
 
 現在の commit を添えて記録します。効くのは `deferred` です。`QUALITY.md` の **Carried over** チェックリストに、見た時点の commit 付きで出ます。「router.ts は分割が必要」というメモは、400コミット後には*いつ真だったのか*が分からなければ役に立たないからです。
 
+### `emit-diff`
+
+```bash
+ever-better emit-diff                  # HEAD と比較
+ever-better emit-diff --against main
+```
+
+作業ツリーと git ref をそれぞれコンパイルし、**生成された JavaScript** を比較します。
+
+型だけを動かすリファクタリング — 引数の型を狭める、`as` を消す、interface を分割する — はコンパイル時に消えます。出力がバイト単位で同一なら、その変更が振る舞いを変え得ないことが**証明**されます。どれだけテストを書いてもここまで強くは言えませんし、所要時間は数秒です。差分が出た場合は、出たファイルがそのまま「見るべき場所」になります。
+
 ### `status`
 
 現在のフェーズ、残りの件数、そして残件数が**少ない**ルール — つまり最初に片付けるべきルール — を表示します。診断から30日超・50コミット超、あるいは記録した commit がこの履歴に無い（rebase / force-push）場合は、先頭に `STALE` 行が出ます。ratchet 自体は陳腐化しません（ESLint が現ツリーに対して維持するため）が、gap 一覧・ファイルサイズ・見送りメモは陳腐化します。

--- a/README.md
+++ b/README.md
@@ -168,6 +168,20 @@ renders into a **Carried over** checklist in `QUALITY.md` with the commit it was
 "router.ts needs splitting" is useless four hundred commits later unless a reader can tell when it
 was true.
 
+### `emit-diff`
+
+```bash
+ever-better emit-diff                  # against HEAD
+ever-better emit-diff --against main
+```
+
+Compiles the working tree and a git ref, and compares the emitted JavaScript.
+
+A refactor that only moves types — narrowing a parameter, deleting an `as`, splitting an interface
+— erases at compile time. Byte-identical output **proves** the change cannot alter behaviour, which
+no amount of test coverage states as strongly and which takes seconds rather than an afternoon.
+When the output does differ, the files it names are where to look.
+
 ### `status`
 
 Prints the current phase, the backlog, and the rules with the smallest remaining counts — which

--- a/skills/ever-better-drain/SKILL.md
+++ b/skills/ever-better-drain/SKILL.md
@@ -68,11 +68,59 @@ This repo is the worked example: `gatherFacts` is the only function that touches
 detection, `diagnose` is pure over what it returns, and that is why the diagnosis has real tests
 and no fixtures on disk.
 
-### 5. Write the test before moving on
+### 5. Write the test — then make it fail on purpose
 
-Cover the case that was broken, plus the boundary either side of it. Then **break the fix on
-purpose and run the test** — a test that passes against the bug is worse than no test, and this is
-the only way to know.
+Cover the case that was broken, plus the boundary either side of it.
+
+**Then break the thing under test and run the test again.** Revert the fix, or flip a comparison,
+or return a constant. If the test still passes, it is testing nothing: it asserts on a value the
+bug never touched, or mocks the very code it claims to cover. Restore, and confirm it goes green.
+
+This costs thirty seconds and is the only thing that distinguishes a test from a decoration. A
+suite that never went red is a suite nobody has evidence for — the count went up and the coverage
+did not.
+
+The same applies to a rule you have just switched on: make one violation on purpose and confirm the
+lint reports it. A rule that is enabled and silently finds nothing reads exactly like a clean
+codebase.
+
+### 5b. For a type-only refactor, prove it rather than test it
+
+Narrowing a parameter, deleting an `as`, splitting an interface, adding a guard that replaces a
+cast — all of it erases at compile time. So compile before and after and compare the output:
+
+```bash
+npx ever-better emit-diff              # against HEAD
+npx ever-better emit-diff --against main
+```
+
+Byte-identical emitted JavaScript **proves** the change cannot alter behaviour. No amount of test
+coverage states that as strongly, and it takes seconds rather than an afternoon of writing tests
+for code you did not mean to change.
+
+When the output does differ, the files it names are exactly where to look — and usually the answer
+is that the refactor was not type-only after all, which is worth knowing before review rather than
+after.
+
+### 5c. Leave the code more readable than the rule required
+
+The rule is the trigger, not the goal. While you are in the function anyway, take the cheap wins —
+but only the cheap ones, and only in the same commit if they are genuinely mechanical:
+
+- **A name should not need a comment.** `elapsedMs`, not `t` with `// milliseconds`. Units belong
+  in the name; so does the unit of measure in a boolean — `hasExpired` beats `expired`.
+- **Delete the comment that restates the code.** Keep the one that says *why*, especially why the
+  obvious alternative was rejected. A comment that will not age is a comment about a constraint.
+- **Give an unexplained value a name.** A bare `86400` in a condition is a question; `SECONDS_PER_DAY`
+  is an answer.
+- **Return early.** Most `max-depth` and `complexity` findings are one guard clause away from
+  disappearing, and the version with early returns reads top to bottom instead of inside out.
+- **One job per function.** If you cannot name it without "and", that is two functions — and the
+  split is usually what makes the pure half testable.
+- **Shrink the scope.** A variable declared far from its use is a variable the reader has to carry.
+
+Do not turn a lint fix into a rewrite. If the readable version is a genuine redesign, that is an
+issue, not this commit.
 
 ### 6. Reclaim the ceiling
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import process from "node:process";
 import { runBootstrap } from "./commands/bootstrap.ts";
 import { runCheck } from "./commands/check.ts";
 import { runDiagnose } from "./commands/diagnose.ts";
+import { runEmitDiff } from "./commands/emitDiff.ts";
 import { runFreeze } from "./commands/freeze.ts";
 import { isLogKind, LOG_KIND_LIST, runLog } from "./commands/log.ts";
 import { runPrune } from "./commands/prune.ts";
@@ -18,6 +19,7 @@ const USAGE = `ever-better — make a codebase that can only get better
   prune       reclaim suppressions you have fixed     (lowers the ceiling)
   check       fail if anything rose above its ceiling (for CI)
   status      print the current backlog
+  emit-diff   prove a type-only refactor changed no behaviour
   log         record what happened, stamped with the current commit
 
 Options
@@ -30,6 +32,7 @@ Options
   --node <version>  node version for the generated workflow (default: ${DEFAULT_NODE_VERSION})
   --kind <kind>     log: ${LOG_KIND_LIST}
   --rule <name>     log: the rule this entry is about
+  --against <ref>   emit-diff: git ref to compare against (default: HEAD)
 `;
 
 const OPTIONS = {
@@ -42,6 +45,7 @@ const OPTIONS = {
   node: { type: "string", default: DEFAULT_NODE_VERSION },
   kind: { type: "string", default: "note" },
   rule: { type: "string" },
+  against: { type: "string", default: "HEAD" },
   help: { type: "boolean", default: false },
 } as const;
 
@@ -54,6 +58,7 @@ type Flags = {
   noWrite: boolean;
   node: string;
   kind: string;
+  against: string;
   rule: string | undefined;
   rest: string[];
 };
@@ -76,6 +81,9 @@ const dispatch = async (
   }
   if (command === "freeze") {
     return { output: await runFreeze({ cwd: flags.cwd, force: flags.force }), ok: true };
+  }
+  if (command === "emit-diff") {
+    return { output: await runEmitDiff({ cwd: flags.cwd, against: flags.against }), ok: true };
   }
   if (command === "prune") {
     return { output: await runPrune({ cwd: flags.cwd }), ok: true };
@@ -123,6 +131,7 @@ const main = async (): Promise<number> => {
     noWrite: values["no-write"],
     node: values.node,
     kind: values.kind,
+    against: values.against,
     rule: values.rule,
     rest: positionals.slice(1),
   };

--- a/src/commands/emitDiff.ts
+++ b/src/commands/emitDiff.ts
@@ -1,0 +1,92 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, readdir, readFile, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { compareEmit, describeComparison, type EmittedFile } from "../emitCompare.ts";
+import { exec } from "../util/exec.ts";
+
+export type EmitDiffOptions = {
+  cwd: string;
+  /** Git ref to compare against. */
+  against: string;
+};
+
+const TSC_ARGS = [
+  "--noEmit",
+  "false",
+  "--declaration",
+  "false",
+  "--declarationMap",
+  "false",
+  // Source maps embed the input path, so two identical outputs would differ on it alone.
+  "--sourceMap",
+  "false",
+];
+
+const hashOf = async (filePath: string): Promise<string> =>
+  createHash("sha256")
+    .update(await readFile(filePath))
+    .digest("hex");
+
+const collectEmitted = async (root: string, prefix = ""): Promise<EmittedFile[]> => {
+  const entries = await readdir(path.join(root, prefix), { withFileTypes: true });
+  const nested = await Promise.all(
+    entries.map(async (entry) => {
+      const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) return collectEmitted(root, relative);
+      return [{ path: relative, hash: await hashOf(path.join(root, relative)) }];
+    }),
+  );
+  return nested.flat();
+};
+
+const compileTo = async (projectDir: string, outDir: string): Promise<boolean> => {
+  const tsc = path.join(projectDir, "node_modules", "typescript", "bin", "tsc");
+  const result = await exec(
+    process.execPath,
+    [tsc, ...TSC_ARGS, "--outDir", outDir, "--pretty", "false"],
+    projectDir,
+  );
+  // Type errors are irrelevant here — tsc still emits, and emitting is the whole point.
+  return result.code < 2 || (await readdir(outDir).catch(() => [])).length > 0;
+};
+
+/**
+ * Compiles the working tree and a git ref, and compares the emitted JavaScript.
+ *
+ * A refactor that only moves types — narrowing a parameter, deleting an `as`, splitting an
+ * interface — erases at compile time. Byte-identical output proves it cannot have changed
+ * behaviour, which no amount of test coverage can say as strongly. When the output does differ, the
+ * files listed are exactly where to look.
+ */
+export const runEmitDiff = async (options: EmitDiffOptions): Promise<string> => {
+  const scratch = await mkdtemp(path.join(tmpdir(), "ever-better-emit-"));
+  const worktree = path.join(scratch, "before");
+  const beforeOut = path.join(scratch, "out-before");
+  const afterOut = path.join(scratch, "out-after");
+
+  try {
+    const added = await exec(
+      "git",
+      ["worktree", "add", "--detach", worktree, options.against],
+      options.cwd,
+    );
+    if (added.code !== 0) {
+      return `Could not check out ${options.against}:\n${added.stderr.slice(0, 1000)}`;
+    }
+    // The checkout has no node_modules, and installing one would take longer than the comparison.
+    await symlink(path.join(options.cwd, "node_modules"), path.join(worktree, "node_modules"));
+
+    const compiledBefore = await compileTo(worktree, beforeOut);
+    const compiledAfter = await compileTo(options.cwd, afterOut);
+    if (!compiledBefore || !compiledAfter) {
+      return "tsc produced no output for one of the two trees — cannot compare.";
+    }
+
+    const comparison = compareEmit(await collectEmitted(beforeOut), await collectEmitted(afterOut));
+    return describeComparison(comparison, options.against);
+  } finally {
+    await exec("git", ["worktree", "remove", "--force", worktree], options.cwd).catch(() => null);
+    await rm(scratch, { recursive: true, force: true });
+  }
+};

--- a/src/emitCompare.ts
+++ b/src/emitCompare.ts
@@ -1,0 +1,63 @@
+export type EmittedFile = {
+  path: string;
+  hash: string;
+};
+
+export type EmitComparison = {
+  identical: boolean;
+  changed: string[];
+  added: string[];
+  removed: string[];
+};
+
+const byPath = (files: readonly EmittedFile[]): Map<string, string> =>
+  new Map(files.map((file) => [file.path, file.hash]));
+
+/**
+ * Pure comparison of two compiler outputs.
+ *
+ * A TypeScript refactor that only moves types around — narrowing a parameter, deleting an `as`,
+ * splitting an interface — erases at compile time. If the emitted JavaScript is byte-identical then
+ * the change provably cannot alter behaviour, and no amount of test coverage says that as strongly.
+ * When it is not identical, the files listed are exactly where to look.
+ */
+export const compareEmit = (
+  before: readonly EmittedFile[],
+  after: readonly EmittedFile[],
+): EmitComparison => {
+  const first = byPath(before);
+  const second = byPath(after);
+  const changed = [...first.entries()]
+    .filter(([path, hash]) => second.has(path) && second.get(path) !== hash)
+    .map(([path]) => path)
+    .sort((left, right) => left.localeCompare(right));
+  const added = [...second.keys()]
+    .filter((path) => !first.has(path))
+    .sort((left, right) => left.localeCompare(right));
+  const removed = [...first.keys()]
+    .filter((path) => !second.has(path))
+    .sort((left, right) => left.localeCompare(right));
+  return {
+    identical: changed.length === 0 && added.length === 0 && removed.length === 0,
+    changed,
+    added,
+    removed,
+  };
+};
+
+export const describeComparison = (comparison: EmitComparison, ref: string): string => {
+  if (comparison.identical) {
+    return [
+      `The emitted JavaScript is byte-identical to ${ref}.`,
+      "This refactor provably cannot change behaviour — the difference erased at compile time.",
+    ].join("\n");
+  }
+  const section = (label: string, paths: readonly string[]): string[] =>
+    paths.length === 0 ? [] : [`${label}:`, ...paths.map((path) => `  ${path}`)];
+  return [
+    `The emitted JavaScript differs from ${ref}. These are where behaviour could have changed:`,
+    ...section("changed", comparison.changed),
+    ...section("added", comparison.added),
+    ...section("removed", comparison.removed),
+  ].join("\n");
+};

--- a/test/test_emitCompare.ts
+++ b/test/test_emitCompare.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { compareEmit, describeComparison } from "../src/emitCompare.ts";
+
+const file = (path: string, hash: string) => ({ path, hash });
+
+describe("compareEmit", () => {
+  it("calls identical output identical", () => {
+    const files = [file("a.js", "1"), file("b.js", "2")];
+    assert.equal(compareEmit(files, files).identical, true);
+  });
+
+  it("names the file whose emitted JavaScript moved", () => {
+    const result = compareEmit([file("a.js", "1")], [file("a.js", "2")]);
+    assert.equal(result.identical, false);
+    assert.deepEqual(result.changed, ["a.js"]);
+  });
+
+  it("separates added and removed from changed", () => {
+    const result = compareEmit([file("gone.js", "1")], [file("new.js", "1")]);
+    assert.deepEqual(result.removed, ["gone.js"]);
+    assert.deepEqual(result.added, ["new.js"]);
+    assert.deepEqual(result.changed, []);
+  });
+
+  it("treats two empty outputs as identical rather than as an error", () => {
+    assert.equal(compareEmit([], []).identical, true);
+  });
+
+  it("orders each list, so two runs read the same", () => {
+    const before = [file("b.js", "1"), file("a.js", "1")];
+    const after = [file("b.js", "2"), file("a.js", "2")];
+    assert.deepEqual(compareEmit(before, after).changed, ["a.js", "b.js"]);
+  });
+});
+
+describe("describeComparison", () => {
+  it("states the proof plainly when nothing moved", () => {
+    // This is the whole value of the technique: no amount of test coverage says "cannot have
+    // changed behaviour" as strongly as identical compiler output does.
+    const message = describeComparison(compareEmit([], []), "HEAD");
+    assert.match(message, /byte-identical to HEAD/);
+    assert.match(message, /provably cannot change behaviour/);
+  });
+
+  it("points at the files to look at when something did move", () => {
+    const message = describeComparison(
+      compareEmit([file("a.js", "1")], [file("a.js", "2")]),
+      "main",
+    );
+    assert.match(message, /differs from main/);
+    assert.match(message, /a\.js/);
+  });
+
+  it("omits a section that has nothing in it", () => {
+    const message = describeComparison(
+      compareEmit([file("a.js", "1")], [file("a.js", "2")]),
+      "HEAD",
+    );
+    assert.ok(!message.includes("added:"));
+    assert.ok(!message.includes("removed:"));
+  });
+});


### PR DESCRIPTION
## Summary

Two verification techniques that make "refactor without breaking it" checkable rather than hoped for.

**`ever-better emit-diff`** compiles the working tree and a git ref and compares the emitted
JavaScript. A refactor that only moves types — narrowing a parameter, deleting an `as`, splitting an
interface — erases at compile time, so **byte-identical output proves the change cannot alter
behaviour**. No amount of test coverage states that as strongly, and it takes seconds rather than an
afternoon of writing tests for code you did not mean to change.

**Make the test fail on purpose.** The drain skill now requires it: write the test, then revert the
fix, flip a comparison, or return a constant. A test that still passes is testing nothing, and a
suite that has never gone red is a suite nobody has evidence for.

## Items to Confirm / Review

1. **Verified both directions on this repository.** A `Readonly<>` added to a parameter came back
   *byte-identical*; changing a returned string named `src/emitCompare.js` exactly.
2. **Source maps and declarations are disabled for the comparison.** A source map embeds the input
   path, so two identical outputs would differ on that alone.
3. **The "before" tree is a `git worktree`** with `node_modules` symlinked from the working copy —
   installing into it would take longer than the comparison it enables. Removed in a `finally`.
4. **Type errors do not abort it.** `tsc` still emits, and emitting is the whole point; a refactor
   mid-flight is exactly when this is most useful.
5. **The same "make it fail" rule now applies to a rule just switched on** — make one violation and
   confirm it is reported. A rule that is enabled and silently finds nothing reads exactly like a
   clean codebase, which is the failure mode that cost three attempts in #20.

## Also

The drain skill gains the readable-code wins worth taking while already inside a function — units in
names, deleting comments that restate the code, naming bare constants, early returns, one job per
function, smallest scope — with the boundary stated: a lint fix is not a rewrite, and a genuine
redesign is an issue.

## Gate

`format:check`, `lint`, `typecheck`, `build`, **190** tests, `knip` clean.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)