### PR TITLE
test: the lifecycle end to end, against real ESLint

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,40 @@
+# The lifecycle against real ESLint in a real repository: bootstrap, freeze, reject a new
+# violation, fix one, watch the ceiling fall.
+#
+# Its own workflow rather than a step in `ci`, because it installs real packages and takes about
+# forty seconds — the unit suite runs in under a second and should not wait for it. Ubuntu only:
+# what it exercises is the tool's behaviour, and the platform-specific parts are already covered by
+# the three-runner matrix in `ci`.
+name: e2e
+
+on:
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: Lifecycle (real ESLint)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+
+      - run: yarn install --frozen-lockfile
+
+      - run: yarn build
+
+      - run: yarn test:e2e

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "prepack": "yarn build",
     "knip": "knip",
     "duplication": "npx --yes jscpd@4 . --format typescript,javascript --ignore \"**/node_modules/**,**/dist/**,**/*.d.ts\" --reporters console",
-    "docs": "node scripts/write-docs.ts"
+    "docs": "node scripts/write-docs.ts",
+    "test:e2e": "node --test \"test/e2e/*.e2e.ts\""
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/test/e2e/lifecycle.e2e.ts
+++ b/test/e2e/lifecycle.e2e.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { after, before, describe, it } from "node:test";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const cli = path.join(repoRoot, "dist", "cli.js");
+
+/** Installing real packages is the slow part, and the reason this is not in `yarn test`. */
+const TIMEOUT_MS = 600_000;
+
+type Run = { code: number; stdout: string; stderr: string };
+
+const run = (command: string, args: readonly string[], cwd: string): Promise<Run> =>
+  new Promise((resolve, reject) => {
+    const child = spawn(command, [...args], { cwd, shell: false });
+    const out: Buffer[] = [];
+    const err: Buffer[] = [];
+    child.stdout.on("data", (chunk: Buffer) => out.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => err.push(chunk));
+    child.on("error", reject);
+    child.on("close", (code) =>
+      resolve({
+        code: code ?? 1,
+        stdout: Buffer.concat(out).toString("utf8"),
+        stderr: Buffer.concat(err).toString("utf8"),
+      }),
+    );
+  });
+
+const everBetter = (args: readonly string[], cwd: string) =>
+  run(process.execPath, [cli, ...args], cwd);
+
+const MESSY_SOURCE = `export const parse = (input: any) => {
+  const out: any = {};
+  for (const part of input.split("&")) {
+    const [key, value] = part.split("=");
+    out[key] = value;
+  }
+  return out;
+};
+
+export const deep = (aaa: number, bbb: number, ccc: number, ddd: number): string => {
+  if (aaa > 0) {
+    if (bbb > 0) {
+      if (ccc > 0) {
+        if (ddd > 0) {
+          if (aaa + bbb > ccc) return "yes";
+        }
+      }
+    }
+  }
+  return "no";
+};
+`;
+
+/**
+ * The lifecycle, against real ESLint, in a real repository. Every claim this tool makes about the
+ * ratchet lives here — that old code is grandfathered, that new code is rejected, and that fixing
+ * something lowers the ceiling rather than breaking the build.
+ *
+ * Hand-verified through the whole of development; automated so a regression is caught by CI rather
+ * than by whoever runs it next.
+ */
+describe("lifecycle", { timeout: TIMEOUT_MS }, () => {
+  let repo = "";
+
+  before(async () => {
+    repo = await mkdtemp(path.join(tmpdir(), "ever-better-e2e-"));
+    await mkdir(path.join(repo, "src"), { recursive: true });
+    await run("git", ["init", "-q", "."], repo);
+    await writeFile(
+      path.join(repo, "package.json"),
+      `${JSON.stringify({ name: "e2e-fixture", private: true, version: "1.0.0", type: "module" }, null, 2)}\n`,
+    );
+    await writeFile(
+      path.join(repo, "tsconfig.json"),
+      `${JSON.stringify(
+        {
+          compilerOptions: {
+            target: "ES2022",
+            module: "nodenext",
+            moduleResolution: "nodenext",
+            strict: true,
+            noEmit: true,
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await writeFile(path.join(repo, "src", "messy.ts"), MESSY_SOURCE);
+  });
+
+  after(async () => {
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  it("diagnoses a bare repository without throwing", async () => {
+    const result = await everBetter(["diagnose"], repo);
+    assert.equal(result.code, 0, result.stderr);
+    assert.match(result.stdout, /ESLint is not configured/);
+  });
+
+  it("bootstraps a working toolchain", async () => {
+    const result = await everBetter(["bootstrap"], repo);
+    assert.equal(result.code, 0, result.stderr);
+    const lint = await run(path.join(repo, "node_modules", ".bin", "eslint"), ["."], repo).catch(
+      () => null,
+    );
+    // 1 means violations found — the config loaded and the rules ran, which is the point.
+    assert.ok(
+      lint !== null && lint.code < 2,
+      `eslint could not run: ${lint?.stderr ?? "spawn failed"}`,
+    );
+  });
+
+  it("freezes today's violations as the ceiling", async () => {
+    const result = await everBetter(["freeze"], repo);
+    assert.equal(result.code, 0, result.stderr);
+    assert.match(result.stdout, /Baseline pinned: \d+ violations/);
+  });
+
+  it("passes check immediately after freezing", async () => {
+    const result = await everBetter(["check"], repo);
+    assert.equal(result.code, 0, result.stdout + result.stderr);
+    assert.match(result.stdout, /Clean\./);
+  });
+
+  it("rejects a violation added after the freeze", async () => {
+    await writeFile(path.join(repo, "src", "new.ts"), "export const sneaky = (x: any) => x;\n");
+    const result = await everBetter(["check"], repo);
+    assert.equal(result.code, 1, "a new violation must fail the gate");
+    assert.match(result.stdout, /unsuppressed error/);
+  });
+
+  it("passes again once the new violation is gone", async () => {
+    await rm(path.join(repo, "src", "new.ts"));
+    const result = await everBetter(["check"], repo);
+    assert.equal(result.code, 0, result.stdout + result.stderr);
+  });
+
+  it("lowers the ceiling when a grandfathered violation is fixed", async () => {
+    const before = await everBetter(["status"], repo);
+    const backlogBefore = Number(/backlog\s+(\d+)/.exec(before.stdout)?.[1] ?? "0");
+    assert.ok(backlogBefore > 0, "fixture should start with a backlog");
+
+    await writeFile(
+      path.join(repo, "src", "messy.ts"),
+      MESSY_SOURCE.replace(/export const deep[\s\S]*$/, ""),
+    );
+    const pruned = await everBetter(["prune"], repo);
+    assert.equal(pruned.code, 0, pruned.stderr);
+
+    const after = await everBetter(["status"], repo);
+    const backlogAfter = Number(/backlog\s+(\d+)/.exec(after.stdout)?.[1] ?? "0");
+    assert.ok(
+      backlogAfter < backlogBefore,
+      `ceiling did not fall: ${backlogBefore} -> ${backlogAfter}`,
+    );
+  });
+
+  it("refuses a second freeze, which would forgive everything added since", async () => {
+    const result = await everBetter(["freeze"], repo);
+    assert.match(result.stdout, /Already frozen/);
+  });
+});


### PR DESCRIPTION
## Summary

Every claim this tool makes about the ratchet was hand-verified through development and asserted by
nothing. Now it is a test:

1. diagnose a bare repository without throwing
2. bootstrap a working toolchain — and confirm `eslint .` actually runs
3. freeze today's violations as the ceiling
4. check passes immediately after
5. **a violation added afterwards is rejected**
6. removing it goes green again
7. **fixing a grandfathered one lowers the ceiling** via `prune`
8. a second `freeze` is refused

36 seconds locally, all eight green.

## Items to Confirm / Review

- **Its own script and its own workflow, not a step in `ci`.** It installs real packages and takes
  about forty seconds; the unit suite runs in under a second and should not wait for it.
- **Ubuntu only.** What it exercises is behaviour; the platform-specific parts already have the
  three-runner matrix in `ci`.
- **It spawns `dist/cli.js`**, so it tests the binary users get rather than the functions behind it.
- `yarn test` does not pick it up — `test/*.ts` does not match `test/e2e/*.e2e.ts`. Verified.

## Gate

`format:check`, `lint`, `typecheck`, `build`, 194 unit tests, 8 e2e, `knip` clean.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)