### PR TITLE
docs: 0.3.0 — refresh the handoff and state the target

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Make an existing codebase one that can only get better",
-    "version": "0.2.0"
+    "version": "0.3.0"
   },
   "plugins": [
     {
@@ -15,7 +15,7 @@
         "repo": "isamu/ever-better"
       },
       "description": "Diagnose a repository, install the quality tooling it is missing, and pin a baseline that can only get better",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "author": {
         "name": "isamu"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ever-better",
   "description": "Diagnose a repository, install the quality tooling it is missing, and pin a baseline that can only get better",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "isamu",
     "url": "https://github.com/isamu"

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -104,39 +104,36 @@ Keep the three-platform matrix. It is the only thing that sees this class of bug
 
 ## What is NOT built
 
-- **P3 drain, P4 tighten, P5 split & DRY.** No skills yet. This is the next and most valuable work.
-- **No end-to-end test.** The lifecycle above was verified by hand. Automating it — a fixture repo,
-  bootstrap, freeze, assert `check` rejects an added violation — is the highest-value test left.
-- **knip and jscpd are diagnosed but not installed.** `bootstrap` reports them as gaps and stops
-  there. Their counters have a place in `state.json` (`counters`) and nothing writes it yet.
-- **No monorepo support.** One baseline per repository. The state shape leaves room for more.
-Published and verified on 2026-08-08:
+- **JS → TS migration.** It is DIAGNOSED — `diagnose` reports a JavaScript repo and says the
+  type-aware tier cannot run without types — and the bootstrap skill says to ask before migrating.
+  Nothing performs the migration. This was in scope from the first decision and is the largest
+  remaining gap.
+- **No monorepo support.** One baseline per repository; the state shape leaves room for more.
+- **Python.** Assessed and deferred — see the section above.
 
-- **`ever-better@0.1.0` is on npm.** `npx ever-better@0.1.0 check` was run against the Vue fixture
-  from a clean fetch and behaved correctly, so the `npx ever-better check` step in every generated
-  workflow now resolves.
-- **The plugin installs.** `claude plugin validate . --strict` passes, and
-  `claude plugin marketplace add isamu/ever-better` followed by
-  `claude plugin install ever-better@ever-better` registers all three skills (~419 always-on tokens).
+## The target state
 
-Before the next release, run `npm pack --dry-run` and check the file list. The first publish
-attempt would have shipped without `formatters/rule-counts.js` — every counting command broken for
-installed users, and nothing in the test suite could see it.
+What a repository looks like when the process has run to completion, so it is clear what all of
+this is for:
+
+- **CI locked down.** Lint, typecheck, build, tests on three platforms; the gate rejecting any new
+  violation; duplication and dead code reported per pull request; a second model reviewing the diff.
+- **Complexity gone.** SonarJS cognitive complexity, function length, nesting and branch counts all
+  enforced, with the backlog drained to zero rather than grandfathered forever.
+- **Types complete.** `strict` plus every flag it does not include, and the type-aware lint tier
+  enforcing rather than warning.
+- **Tests that have been seen to fail**, covering the pure functions the drain phase extracted.
+
+The point of the whole thing: **whoever writes the next line cannot break it quietly.**
 
 ## Suggested next steps, in order
 
-1. **Publish 0.1.0 to npm.** Nothing else can be tried by another person until `npx ever-better`
-   resolves.
-2. **Verify the plugin installs.** `/plugin marketplace add isamu/ever-better`, then check the
-   three skills appear and the entry-point skill routes correctly.
-3. **Run it on a real repo that is not this one.** `~/tne/orion` is the obvious candidate, and the
-   one the process was designed against. Expect the diagnosis to be right and the generated config
-   to need one or two adjustments — capture those as generator changes, not local edits.
-4. **Write the `ever-better-drain` skill (P3).** Read `QUALITY.md`, take the smallest backlog, fix
-   it rule by rule, extract pure functions where a fix needs a test, `prune`, commit. This is where
-   the original process actually lives.
-5. **Add the end-to-end test.**
-6. **Then P4 / P5.**
+1. **JS → TS migration.** The one thing from the original scope with no implementation.
+2. **Run it on a repository that is not this one.** `~/tne/orion` is the obvious candidate. Expect
+   the diagnosis to be right and the generated config to need one or two adjustments — capture
+   those as generator changes, not local edits.
+3. **Monorepo support**, if a target needs it.
+4. **Python**, after the above.
 
 ## Reference material
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ever-better",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Diagnose a repository, install the quality tooling it is missing, and pin a baseline that can only get better.",
   "keywords": [
     "eslint",


### PR DESCRIPTION
## Summary

A conversation review turned up three gaps. Two are fixed here; the third needs a decision.

1. **Everything since 0.2.0 is unpublished.** `strengthen`, tsconfig strictness, the gate workflow,
   security and readability tiers, `prepare`, Codex review, `emit-diff`, `catalog`, the end-to-end
   test — none of it exists for anyone installing from npm or the plugin marketplace. Bumped to
   **0.3.0**; publishing after this merges.

2. **HANDOFF was stale** — it still listed the end-to-end test and the scan tooling as not built.

3. **JS → TS migration has no implementation.** It was in scope from the first decision. `diagnose`
   reports a JavaScript repo and says the type-aware tier cannot run without types, and the
   bootstrap skill says to ask before migrating — but nothing performs it. Now recorded as the one
   outstanding item rather than assumed done.

## Also

The **target state** is written down for the first time. It was described in conversation and
existed nowhere in the repository:

> CI locked down; complexity drained rather than grandfathered; types complete; tests that have
> been seen to fail — so that whoever writes the next line cannot break it quietly.

## Gate

`format:check`, `lint`, `typecheck`, `build`, 208 tests, `knip` clean, plugin manifest valid.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)