### PR TITLE
feat: migrate — JavaScript to TypeScript, one file at a time

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -132,6 +132,19 @@ ever-better log --kind issue    --rule no-floating-promises "#42 を起票 — �
 
 現在の commit を添えて記録します。効くのは `deferred` です。`QUALITY.md` の **Carried over** チェックリストに、見た時点の commit 付きで出ます。「router.ts は分割が必要」というメモは、400コミット後には*いつ真だったのか*が分からなければ役に立たないからです。
 
+### `migrate`
+
+```bash
+ever-better migrate                              # 依存順の移行計画
+ever-better migrate --file src/util/text.js      # 1ファイル改名、コスト付き
+```
+
+JavaScript から TypeScript へ、1コミット1ファイルで進めます。まず `allowJs` + `checkJs: false` の `tsconfig.json` を書いて「今のまま」コンパイルが通る状態を作り、そこから1ファイルずつ改名して**型エラーが何件増えたか**を報告します。
+
+**1ファイルずつなのは慎重さではありません。** 型エラーには suppression の仕組みがありません（`--suppress-all` は lint 違反を grandfather しますが、コンパイラには相当物がない）。一括改名すると `typecheck` が落ちたまま、段階的に進める手段が無いレポジトリが残ります。
+
+**依存の葉から**進めます。順序は import グラフから計算します。import 先がまだ JavaScript のファイルに型を付けるのは `any` に対して型を付けることで、依存側が型付けされた後に全部やり直しになります。
+
 ### `catalog`
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -171,6 +171,24 @@ renders into a **Carried over** checklist in `QUALITY.md` with the commit it was
 "router.ts needs splitting" is useless four hundred commits later unless a reader can tell when it
 was true.
 
+### `migrate`
+
+```bash
+ever-better migrate                              # the plan, in dependency order
+ever-better migrate --file src/util/text.js      # one rename, priced
+```
+
+JavaScript to TypeScript, one file per commit. Writes a `tsconfig.json` with `allowJs` and
+`checkJs: false` first, so the repo compiles exactly as it is today, then renames one file at a time
+and reports how many type errors that cost.
+
+**One at a time is not caution.** Type errors have no suppression mechanism — `--suppress-all`
+grandfathers lint violations and there is no equivalent for the compiler — so a big-bang rename
+leaves a repository whose `typecheck` fails with nothing able to stage the work.
+
+**Dependencies first**, and the order is computed from the import graph. Typing a file whose imports
+are still JavaScript means typing it against `any`, and all of it has to be redone later.
+
 ### `catalog`
 
 ```bash

--- a/skills/ever-better-migrate/SKILL.md
+++ b/skills/ever-better-migrate/SKILL.md
@@ -1,0 +1,105 @@
+---
+description: Move a JavaScript repository to TypeScript one file at a time, dependencies first, fixing the type errors each rename introduces. Use when `diagnose` reports "No TypeScript", or the user says "TypeScript にしたい", "型を入れたい", "migrate this to TypeScript", "ts化して". Not for adding types to a repo that is already TypeScript — that is the drain skill's type tier.
+---
+
+# ever-better migrate
+
+TypeScript is the cheapest rule set there is, and the tier that finds the most real bugs cannot run
+without it. This is how a JavaScript repository gets there without a week of red builds.
+
+## Why one file at a time
+
+**Type errors have no suppression mechanism.** `--suppress-all` grandfathers lint violations; there
+is no equivalent for the compiler. Rename everything at once and you have a repository whose
+`typecheck` fails with thousands of errors and nothing able to stage the work — the state that gets
+a migration reverted.
+
+So: `allowJs` with `checkJs: false` first, which compiles the repo exactly as it is today. Then one
+rename per commit, each with its errors fixed.
+
+## Why dependencies first
+
+`ever-better migrate` prints the order, and it is not alphabetical. Typing a file whose imports are
+still JavaScript means typing it against `any` — and every one of those has to be revisited once the
+dependency is typed. Leaf-first is the difference between doing the work once and doing it twice.
+
+## Steps
+
+### 1. See the plan
+
+```bash
+npx ever-better migrate
+```
+
+Writes `tsconfig.json` if there is none — `allowJs: true`, `checkJs: false`, so nothing is checked
+yet and nothing breaks — then lists the files in dependency order.
+
+**Read the cycles section.** Files in an import cycle cannot be ordered: none can go first, so they
+migrate as one commit. A cycle is also worth reporting to the owner on its own — it is usually a
+design problem that predates the migration.
+
+### 2. Install the toolchain, if it is not there
+
+```bash
+npx ever-better bootstrap
+```
+
+The ESLint config it writes for a JavaScript repo deliberately omits the type-aware tier. Regenerate
+it at the end, when there is something for it to check.
+
+### 3. One file, one commit
+
+```bash
+npx ever-better migrate --file src/util/text.js
+```
+
+It renames the file and reports **how many new type errors that cost**. Fix them in the same commit
+— they cannot be suppressed, so a commit that leaves them makes every later commit look broken.
+
+What the errors usually are, in order of frequency:
+
+| Error | What it is telling you |
+| --- | --- |
+| implicit `any` on a parameter | nobody ever wrote down what this takes |
+| possibly `undefined` | a case the code has always handled by luck |
+| property does not exist | the shape drifted from what callers pass |
+| cannot find module | a `.js` specifier that needs its real extension |
+
+**The second row is a bug, not a typing chore.** When the compiler says a value may be undefined and
+the code dereferences it, that is a crash nobody had reproduced. Fix it, and write the test — say so
+in the commit message rather than folding it into "migrate file X".
+
+### 4. Never reach for a cast
+
+`as`, `!`, `@ts-ignore` and `@ts-nocheck` are all banned by the generated config, and the ban is the
+point of the migration. A cast records that the compiler could not check something and then hides
+that fact from every reader. Write a type guard:
+
+```ts
+const isUser = (value: unknown): value is User =>
+  typeof value === "object" && value !== null && "id" in value;
+```
+
+It is testable, it narrows for every caller, and it fails at the boundary where the data was
+actually wrong rather than three frames later.
+
+### 5. When the last file is done
+
+```bash
+npx ever-better bootstrap   # regenerate the config, now with the type-aware tier
+npx ever-better freeze --force
+```
+
+`--force` is correct here and only here: the rule set genuinely changed, so the ceiling has to be
+re-taken. Say so in the pull request.
+
+Then set `checkJs` aside and delete `allowJs` from the tsconfig — with no `.js` left, both are
+dead configuration that will confuse the next reader.
+
+## What becomes an issue
+
+- **A file whose types are a redesign.** If typing it honestly means changing what it does, that is
+  a decision for the owner, not a migration commit.
+- **A cycle that should be broken rather than migrated as a unit.**
+- **A dependency with no types at all.** Whether to write a `.d.ts`, switch package, or accept a
+  boundary of `unknown` is not yours to pick.

--- a/skills/ever-better/SKILL.md
+++ b/skills/ever-better/SKILL.md
@@ -58,6 +58,8 @@ issue says what the options are and which one you would pick.
    - no `CLAUDE.md` / `AGENTS.md`, or a first run on this repo → the **`ever-better-prepare`**
      skill. Everything after it is done by an agent reading instructions; thin instructions produce
      a different answer every session and nobody can tell which was right.
+   - the repo is JavaScript → the **`ever-better-migrate`** skill. Types are the cheapest rule set
+     there is, and the tier that finds the most real bugs cannot run without them.
    - anything in the `bootstrap` phase → the **`ever-better-bootstrap`** skill
    - bootstrap clean, nothing frozen yet → the **`ever-better-freeze`** skill
    - already frozen, backlog remaining → the **`ever-better-drain`** skill

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { runDiagnose } from "./commands/diagnose.ts";
 import { runEmitDiff } from "./commands/emitDiff.ts";
 import { runFreeze } from "./commands/freeze.ts";
 import { isLogKind, LOG_KIND_LIST, runLog } from "./commands/log.ts";
+import { runMigrate } from "./commands/migrate.ts";
 import { runPrune } from "./commands/prune.ts";
 import { runStatus } from "./commands/status.ts";
 
@@ -22,6 +23,7 @@ const USAGE = `ever-better — make a codebase that can only get better
   status      print the current backlog
   emit-diff   prove a type-only refactor changed no behaviour
   catalog     list the helpers that already exist, so nobody writes a sixth
+  migrate     JavaScript to TypeScript, one file at a time, in dependency order
   log         record what happened, stamped with the current commit
 
 Options
@@ -35,6 +37,7 @@ Options
   --kind <kind>     log: ${LOG_KIND_LIST}
   --rule <name>     log: the rule this entry is about
   --against <ref>   emit-diff: git ref to compare against (default: HEAD)
+  --file <path>     migrate: the one file to rename (omit to see the plan)
 `;
 
 const OPTIONS = {
@@ -48,6 +51,7 @@ const OPTIONS = {
   kind: { type: "string", default: "note" },
   rule: { type: "string" },
   against: { type: "string", default: "HEAD" },
+  file: { type: "string" },
   help: { type: "boolean", default: false },
 } as const;
 
@@ -61,55 +65,43 @@ type Flags = {
   node: string;
   kind: string;
   against: string;
+  file: string | undefined;
   rule: string | undefined;
   rest: string[];
 };
 
-const dispatch = async (
-  command: string,
-  flags: Flags,
-): Promise<{ output: string; ok: boolean }> => {
-  if (command === "diagnose") {
-    const output = await runDiagnose({ cwd: flags.cwd, json: flags.json, write: flags.write });
-    return { output, ok: true };
-  }
-  if (command === "bootstrap") {
-    const output = await runBootstrap({
-      cwd: flags.cwd,
-      dryRun: flags.dryRun,
-      nodeVersion: flags.node,
-    });
-    return { output, ok: true };
-  }
-  if (command === "freeze") {
-    return { output: await runFreeze({ cwd: flags.cwd, force: flags.force }), ok: true };
-  }
-  if (command === "catalog") {
-    return { output: await runCatalog({ cwd: flags.cwd }), ok: true };
-  }
-  if (command === "emit-diff") {
-    return { output: await runEmitDiff({ cwd: flags.cwd, against: flags.against }), ok: true };
-  }
-  if (command === "prune") {
-    return { output: await runPrune({ cwd: flags.cwd }), ok: true };
-  }
+type Outcome = { output: string; ok: boolean };
+
+/** Commands that only ever succeed. `check` and `log` are the two that can fail, below. */
+const ALWAYS_OK: Record<string, (flags: Flags) => Promise<string>> = {
+  diagnose: (flags) => runDiagnose({ cwd: flags.cwd, json: flags.json, write: flags.write }),
+  bootstrap: (flags) =>
+    runBootstrap({ cwd: flags.cwd, dryRun: flags.dryRun, nodeVersion: flags.node }),
+  freeze: (flags) => runFreeze({ cwd: flags.cwd, force: flags.force }),
+  prune: (flags) => runPrune({ cwd: flags.cwd }),
+  status: (flags) => runStatus({ cwd: flags.cwd, json: flags.json }),
+  catalog: (flags) => runCatalog({ cwd: flags.cwd }),
+  migrate: (flags) => runMigrate({ cwd: flags.cwd, file: flags.file ?? null }),
+  "emit-diff": (flags) => runEmitDiff({ cwd: flags.cwd, against: flags.against }),
+};
+
+const dispatchLog = async (flags: Flags): Promise<Outcome> => {
+  if (!isLogKind(flags.kind))
+    return { output: `--kind must be one of: ${LOG_KIND_LIST}`, ok: false };
+  const text = flags.rest.join(" ").trim();
+  if (!text) return { output: 'log needs text: ever-better log --kind deferred "..."', ok: false };
+  // exactOptionalPropertyTypes: an optional property must be OMITTED, not set to undefined.
+  const rule = flags.rule === undefined ? {} : { rule: flags.rule };
+  return { output: await runLog({ cwd: flags.cwd, kind: flags.kind, text, ...rule }), ok: true };
+};
+
+const dispatch = async (command: string, flags: Flags): Promise<Outcome> => {
+  const alwaysOk = ALWAYS_OK[command];
+  if (alwaysOk) return { output: await alwaysOk(flags), ok: true };
+  if (command === "log") return dispatchLog(flags);
   if (command === "check") {
     const result = await runCheck({ cwd: flags.cwd, write: !flags.noWrite });
     return { output: result.message, ok: result.ok };
-  }
-  if (command === "log") {
-    if (!isLogKind(flags.kind))
-      return { output: `--kind must be one of: ${LOG_KIND_LIST}`, ok: false };
-    const text = flags.rest.join(" ").trim();
-    if (!text)
-      return { output: 'log needs text: ever-better log --kind deferred "..."', ok: false };
-    // exactOptionalPropertyTypes: an optional property must be OMITTED, not set to undefined.
-    const rule = flags.rule === undefined ? {} : { rule: flags.rule };
-    const output = await runLog({ cwd: flags.cwd, kind: flags.kind, text, ...rule });
-    return { output, ok: true };
-  }
-  if (command === "status") {
-    return { output: await runStatus({ cwd: flags.cwd, json: flags.json }), ok: true };
   }
   return { output: `Unknown command: ${command}\n\n${USAGE}`, ok: false };
 };
@@ -137,6 +129,7 @@ const main = async (): Promise<number> => {
     node: values.node,
     kind: values.kind,
     against: values.against,
+    file: values.file,
     rule: values.rule,
     rest: positionals.slice(1),
   };

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,0 +1,115 @@
+import { readdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { gatherFacts } from "../facts.ts";
+import { renderJsTsconfig } from "../generate/tsconfigJs.ts";
+import { buildGraph } from "../migrate/importGraph.ts";
+import { migratedName, planMigration } from "../migrate/order.ts";
+import { exec } from "../util/exec.ts";
+import type { SourceFile } from "../types.ts";
+
+export type MigrateOptions = {
+  cwd: string;
+  /** One file to rename, or none to print the plan. */
+  file: string | null;
+};
+
+const JS_EXTENSIONS = new Set(["js", "jsx", "mjs", "cjs"]);
+
+const NEXT_SHOWN = 10;
+
+const javascriptFiles = (files: readonly SourceFile[]): SourceFile[] =>
+  files.filter((file) => JS_EXTENSIONS.has(file.ext));
+
+const countTypeErrors = async (cwd: string): Promise<number | null> => {
+  const tsc = path.join(cwd, "node_modules", "typescript", "bin", "tsc");
+  try {
+    // `--pretty false`: tsc colours its output, and escape codes between "error" and "TS1234" make
+    // a grep silently count zero.
+    const result = await exec(process.execPath, [tsc, "--noEmit", "--pretty", "false"], cwd);
+    const output = `${result.stdout}\n${result.stderr}`;
+    return output.split("\n").filter((line) => line.includes("error TS")).length;
+  } catch {
+    return null;
+  }
+};
+
+const ensureTsconfig = async (cwd: string, rootEntries: readonly string[]): Promise<string[]> => {
+  if (rootEntries.includes("tsconfig.json")) return [];
+  await writeFile(path.join(cwd, "tsconfig.json"), renderJsTsconfig(), "utf8");
+  return ["Wrote tsconfig.json with allowJs and checkJs off — nothing is type-checked yet."];
+};
+
+const hasTypescript = async (cwd: string): Promise<boolean> =>
+  readdir(path.join(cwd, "node_modules", "typescript"))
+    .then(() => true)
+    .catch(() => false);
+
+const describePlan = (order: readonly string[], cycles: readonly string[][]): string[] => [
+  `${order.length} JavaScript files, in dependency order:`,
+  ...order
+    .slice(0, NEXT_SHOWN)
+    .map((file, index) => `  ${index + 1}. ${file} -> ${migratedName(file)}`),
+  ...(order.length > NEXT_SHOWN ? [`  … and ${order.length - NEXT_SHOWN} more`] : []),
+  ...(cycles.length > 0
+    ? [
+        "",
+        `${cycles.length} import cycle(s). Nothing in one can go first, so each migrates as a unit:`,
+        ...cycles.map((cycle) => `  ${cycle.join(" -> ")}`),
+      ]
+    : []),
+];
+
+/**
+ * Renames one JavaScript file and reports what it cost.
+ *
+ * One file at a time is not caution, it is the only thing that works: type errors have no
+ * suppression mechanism, so a big-bang rename leaves a repository whose `typecheck` fails with
+ * nothing able to grandfather it. Dependencies go first — typing a file whose imports are still
+ * JavaScript means typing it against `any`, and all of it has to be redone later.
+ */
+export const runMigrate = async (options: MigrateOptions): Promise<string> => {
+  const facts = await gatherFacts(options.cwd);
+  const javascript = javascriptFiles(facts.sourceFiles);
+  if (javascript.length === 0) return "No JavaScript left to migrate.";
+
+  const created = await ensureTsconfig(options.cwd, facts.rootEntries);
+  const sources = new Map(
+    await Promise.all(
+      javascript.map(async (file): Promise<[string, string]> => [
+        file.path,
+        await readFile(path.join(options.cwd, file.path), "utf8").catch(() => ""),
+      ]),
+    ),
+  );
+  const { order, cycles } = planMigration(buildGraph(sources));
+
+  if (options.file === null) {
+    return [
+      ...created,
+      ...describePlan(order, cycles),
+      "",
+      `Next: ever-better migrate --file ${order[0] ?? ""}`,
+    ].join("\n");
+  }
+
+  if (!sources.has(options.file)) return `${options.file} is not a JavaScript file in this repo.`;
+  if (!(await hasTypescript(options.cwd))) {
+    return "TypeScript is not installed here. Run `ever-better bootstrap` first.";
+  }
+
+  const before = await countTypeErrors(options.cwd);
+  const target = migratedName(options.file);
+  await rename(path.join(options.cwd, options.file), path.join(options.cwd, target));
+  const after = await countTypeErrors(options.cwd);
+
+  const cost = before !== null && after !== null ? after - before : null;
+  return [
+    `${options.file} -> ${target}`,
+    cost === null
+      ? "Could not run tsc to price it — check the result by hand."
+      : `${cost} new type errors. They have no suppression mechanism, so fix them in this commit.`,
+    cost === 0 ? "Nothing to fix. Commit and take the next file." : "",
+  ]
+    .filter((line) => line.length > 0)
+    .join("\n");
+};

--- a/src/diagnose.ts
+++ b/src/diagnose.ts
@@ -40,8 +40,7 @@ const languageGaps = (diagnosis: Omit<Diagnosis, "gaps">): Gap[] => {
         title: "No TypeScript",
         detail:
           "Types are the cheapest rule set there is, and the type-aware lint tier cannot run " +
-          "without them. Migrating is a phase of its own — the ever-better-bootstrap skill covers " +
-          "when to do it and what it unlocks.",
+          "without them. `ever-better migrate` walks it one file at a time, dependencies first.",
         phase: "bootstrap",
       },
     ];

--- a/src/generate/tsconfigJs.ts
+++ b/src/generate/tsconfigJs.ts
@@ -1,0 +1,29 @@
+/**
+ * The tsconfig a JavaScript repository starts with.
+ *
+ * `allowJs` with `checkJs: false` is the whole trick: TypeScript compiles the repo as it is today,
+ * so nothing breaks on the first commit, and each renamed file is then checked while the rest is
+ * left alone. A big-bang rename produces thousands of type errors at once — and type errors have
+ * NO suppression mechanism, so there would be nothing to grandfather them with.
+ */
+export const renderJsTsconfig = (): string =>
+  `${JSON.stringify(
+    {
+      compilerOptions: {
+        target: "ES2022",
+        module: "nodenext",
+        moduleResolution: "nodenext",
+        strict: true,
+        // Compile the JavaScript that is already here, but do not type-check it yet. Each file
+        // becomes checked when it is renamed, which is what makes this incremental.
+        allowJs: true,
+        checkJs: false,
+        noEmit: true,
+        skipLibCheck: true,
+      },
+      include: ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+      exclude: ["node_modules", "dist", "build"],
+    },
+    null,
+    2,
+  )}\n`;

--- a/src/migrate/importGraph.ts
+++ b/src/migrate/importGraph.ts
@@ -1,0 +1,49 @@
+import path from "node:path";
+
+/**
+ * Only relative specifiers matter: a package import is already typed or already is not.
+ *
+ * Anchored per line and with bounded runs rather than `[^'"]*` after an alternation — the latter
+ * backtracks super-linearly, which the repo's own SonarJS tier rejects.
+ */
+const IMPORT = /^[ \t]*(?:import|export)\b[^'"\n]{0,200}['"](\.[^'"\n]{0,200})['"]/gm;
+const REQUIRE = /require\(\s*['"](\.[^'"]*)['"]\s*\)/g;
+
+const JS_EXTENSIONS = ["", ".js", ".jsx", ".mjs", ".cjs", "/index.js", "/index.mjs"];
+
+const collect = (source: string, pattern: RegExp): string[] =>
+  [...source.matchAll(pattern)].map((match) => match[1] ?? "").filter((entry) => entry.length > 0);
+
+/**
+ * Which files in this repo a file depends on. Resolution is by trying the extensions a JavaScript
+ * project actually uses rather than by asking Node: the point is to order a migration, and a
+ * specifier that resolves to nothing here is a specifier pointing outside it.
+ */
+export const resolveLocalImports = (
+  file: string,
+  source: string,
+  known: ReadonlySet<string>,
+): string[] => {
+  const directory = path.posix.dirname(file);
+  const specifiers = [...collect(source, IMPORT), ...collect(source, REQUIRE)];
+  return [
+    ...new Set(
+      specifiers.flatMap((specifier) => {
+        const base = path.posix.normalize(path.posix.join(directory, specifier));
+        const hit = JS_EXTENSIONS.map((extension) => `${base}${extension}`).find((candidate) =>
+          known.has(candidate),
+        );
+        return hit === undefined ? [] : [hit];
+      }),
+    ),
+  ];
+};
+
+export type ImportGraph = Map<string, string[]>;
+
+export const buildGraph = (files: ReadonlyMap<string, string>): ImportGraph => {
+  const known = new Set(files.keys());
+  return new Map(
+    [...files.entries()].map(([file, source]) => [file, resolveLocalImports(file, source, known)]),
+  );
+};

--- a/src/migrate/order.ts
+++ b/src/migrate/order.ts
@@ -1,0 +1,53 @@
+import type { ImportGraph } from "./importGraph.ts";
+
+export type MigrationPlan = {
+  /** Dependencies before dependents: each file's imports are already typed when its turn comes. */
+  order: string[];
+  /** Files in an import cycle. Nothing in one can go first, so they migrate together. */
+  cycles: string[][];
+};
+
+const visit = (
+  file: string,
+  graph: ImportGraph,
+  done: Set<string>,
+  stack: Set<string>,
+  order: string[],
+  cycles: string[][],
+): void => {
+  if (done.has(file)) return;
+  if (stack.has(file)) {
+    cycles.push([...stack].slice([...stack].indexOf(file)));
+    return;
+  }
+  stack.add(file);
+  for (const dependency of graph.get(file) ?? []) {
+    visit(dependency, graph, done, stack, order, cycles);
+  }
+  stack.delete(file);
+  done.add(file);
+  order.push(file);
+};
+
+/**
+ * Leaf-first. Migrating a file whose imports are still JavaScript means typing it against `any`,
+ * and every one of those has to be revisited once the dependency is typed — so the order is the
+ * difference between doing the work once and doing it twice.
+ */
+export const planMigration = (graph: ImportGraph): MigrationPlan => {
+  const done = new Set<string>();
+  const order: string[] = [];
+  const cycles: string[][] = [];
+  for (const file of [...graph.keys()].sort((left, right) => left.localeCompare(right))) {
+    visit(file, graph, done, new Set(), order, cycles);
+  }
+  return { order, cycles };
+};
+
+/** `.js` becomes `.ts`; JSX has to become `.tsx` or the compiler refuses the syntax. */
+export const migratedName = (file: string): string =>
+  file
+    .replace(/\.jsx$/, ".tsx")
+    .replace(/\.mjs$/, ".mts")
+    .replace(/\.cjs$/, ".cts")
+    .replace(/\.js$/, ".ts");

--- a/test/test_migrate.ts
+++ b/test/test_migrate.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildGraph, resolveLocalImports } from "../src/migrate/importGraph.ts";
+import { migratedName, planMigration } from "../src/migrate/order.ts";
+
+const known = (...files: string[]) => new Set(files);
+
+describe("resolveLocalImports", () => {
+  it("resolves a relative import to a file in the repo", () => {
+    const found = resolveLocalImports(
+      "src/a.js",
+      'import { x } from "./b.js";\n',
+      known("src/a.js", "src/b.js"),
+    );
+    assert.deepEqual(found, ["src/b.js"]);
+  });
+
+  it("resolves an extensionless specifier", () => {
+    const found = resolveLocalImports("src/a.js", 'import x from "./b";\n', known("src/b.js"));
+    assert.deepEqual(found, ["src/b.js"]);
+  });
+
+  it("resolves a directory to its index", () => {
+    const found = resolveLocalImports(
+      "src/a.js",
+      'import x from "./util";\n',
+      known("src/util/index.js"),
+    );
+    assert.deepEqual(found, ["src/util/index.js"]);
+  });
+
+  it("follows require as well as import", () => {
+    const found = resolveLocalImports(
+      "src/a.js",
+      'const b = require("./b.js");\n',
+      known("src/b.js"),
+    );
+    assert.deepEqual(found, ["src/b.js"]);
+  });
+
+  it("follows a re-export", () => {
+    const found = resolveLocalImports(
+      "src/a.js",
+      'export { x } from "./b.js";\n',
+      known("src/b.js"),
+    );
+    assert.deepEqual(found, ["src/b.js"]);
+  });
+
+  it("ignores a package import, which is already typed or already is not", () => {
+    const found = resolveLocalImports("src/a.js", 'import fs from "node:fs";\n', known("src/a.js"));
+    assert.deepEqual(found, []);
+  });
+
+  it("ignores a relative specifier pointing outside the repo", () => {
+    const found = resolveLocalImports(
+      "src/a.js",
+      'import x from "./missing.js";\n',
+      known("src/a.js"),
+    );
+    assert.deepEqual(found, []);
+  });
+
+  it("lists each dependency once", () => {
+    const source = 'import { x } from "./b.js";\nimport { y } from "./b.js";\n';
+    assert.deepEqual(resolveLocalImports("src/a.js", source, known("src/b.js")), ["src/b.js"]);
+  });
+});
+
+describe("planMigration", () => {
+  const graph = (entries: Record<string, string[]>) => new Map(Object.entries(entries));
+
+  it("puts a dependency before its dependent", () => {
+    // Typing a file whose imports are still JavaScript means typing it against `any`, and all of
+    // it has to be redone once the dependency is typed.
+    const { order } = planMigration(graph({ "a.js": ["b.js"], "b.js": [] }));
+    assert.deepEqual(order, ["b.js", "a.js"]);
+  });
+
+  it("orders a three-deep chain leaf-first", () => {
+    const { order } = planMigration(graph({ "a.js": ["b.js"], "b.js": ["c.js"], "c.js": [] }));
+    assert.deepEqual(order, ["c.js", "b.js", "a.js"]);
+  });
+
+  it("reports a cycle rather than looping forever", () => {
+    const { cycles } = planMigration(graph({ "a.js": ["b.js"], "b.js": ["a.js"] }));
+    assert.equal(cycles.length > 0, true);
+  });
+
+  it("still lists every file when there is a cycle", () => {
+    const { order } = planMigration(graph({ "a.js": ["b.js"], "b.js": ["a.js"] }));
+    assert.deepEqual(
+      [...order].sort((left, right) => left.localeCompare(right)),
+      ["a.js", "b.js"],
+    );
+  });
+
+  it("is deterministic for unrelated files", () => {
+    const plan = graph({ "b.js": [], "a.js": [] });
+    assert.deepEqual(planMigration(plan).order, planMigration(plan).order);
+  });
+});
+
+describe("buildGraph", () => {
+  it("links the files it was given and nothing else", () => {
+    const files = new Map([
+      ["src/a.js", 'import { b } from "./b.js";\n'],
+      ["src/b.js", 'import fs from "node:fs";\n'],
+    ]);
+    assert.deepEqual(buildGraph(files).get("src/a.js"), ["src/b.js"]);
+    assert.deepEqual(buildGraph(files).get("src/b.js"), []);
+  });
+});
+
+describe("migratedName", () => {
+  it("keeps JSX as .tsx, which the compiler requires for the syntax", () => {
+    assert.equal(migratedName("src/App.jsx"), "src/App.tsx");
+  });
+
+  it("maps the module variants", () => {
+    assert.equal(migratedName("a.mjs"), "a.mts");
+    assert.equal(migratedName("a.cjs"), "a.cts");
+    assert.equal(migratedName("a.js"), "a.ts");
+  });
+
+  it("leaves a path that only contains .js elsewhere alone", () => {
+    assert.equal(migratedName("src/js.helpers/a.js"), "src/js.helpers/a.ts");
+  });
+});


### PR DESCRIPTION
## Summary

The last item from the original scope with no implementation. `diagnose` reported that a JavaScript
repo could not run the tier that finds the most real bugs, and nothing did anything about it.

```bash
ever-better migrate                            # the plan, in dependency order
ever-better migrate --file src/util/text.js    # one rename, priced
```

## Items to Confirm / Review

1. **One file per commit is not caution — it is the only thing that works.** Type errors have **no
   suppression mechanism**; `--suppress-all` grandfathers lint violations and there is no equivalent
   for the compiler. A big-bang rename leaves a repository whose `typecheck` fails with thousands of
   errors and nothing able to stage the work, which is the state that gets a migration reverted.

2. **`allowJs` + `checkJs: false` first**, so the repo compiles exactly as it is today and the first
   commit breaks nothing. Each renamed file becomes checked; the rest is left alone.

3. **The order comes from the import graph, leaf-first.** Typing a file whose imports are still
   JavaScript means typing it against `any`, and all of it has to be redone once the dependency is
   typed. Verified on a three-file chain: `util/text.js` → `greet.js` → `index.js`.

4. **Import cycles are reported, not ordered.** Nothing in one can go first, so they migrate as a
   unit — and a cycle is usually a design problem that predates the migration, worth raising
   separately.

5. **Each rename is priced** with `--pretty false`, because tsc colours its output and a grep
   without it silently counts zero. That trap has now cost two features.

6. **The skill carries what the numbers cannot**: that a "possibly undefined" error is a bug nobody
   had reproduced rather than a typing chore, and that reaching for `as` or `!` defeats the entire
   point of the migration — with the type guard to write instead.

## Also

The CLI dispatcher outgrew the cognitive-complexity limit as the ninth command landed, so it is now
a lookup table with the two commands that can fail handled separately.

## Gate

`format:check`, `lint`, `typecheck`, `build`, **233** unit tests, 8 e2e, `knip` clean, samples page
regenerated.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)