### PR TITLE
docs: 0.4.0 — everything from the original scope has shipped

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Make an existing codebase one that can only get better",
-    "version": "0.3.0"
+    "version": "0.4.0"
   },
   "plugins": [
     {
@@ -15,7 +15,7 @@
         "repo": "isamu/ever-better"
       },
       "description": "Diagnose a repository, install the quality tooling it is missing, and pin a baseline that can only get better",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "author": {
         "name": "isamu"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ever-better",
   "description": "Diagnose a repository, install the quality tooling it is missing, and pin a baseline that can only get better",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "isamu",
     "url": "https://github.com/isamu"

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -104,10 +104,8 @@ Keep the three-platform matrix. It is the only thing that sees this class of bug
 
 ## What is NOT built
 
-- **JS → TS migration.** It is DIAGNOSED — `diagnose` reports a JavaScript repo and says the
-  type-aware tier cannot run without types — and the bootstrap skill says to ask before migrating.
-  Nothing performs the migration. This was in scope from the first decision and is the largest
-  remaining gap.
+Everything from the original scope has shipped. What remains was never in it:
+
 - **No monorepo support.** One baseline per repository; the state shape leaves room for more.
 - **Python.** Assessed and deferred — see the section above.
 
@@ -128,12 +126,11 @@ The point of the whole thing: **whoever writes the next line cannot break it qui
 
 ## Suggested next steps, in order
 
-1. **JS → TS migration.** The one thing from the original scope with no implementation.
-2. **Run it on a repository that is not this one.** `~/tne/orion` is the obvious candidate. Expect
+1. **Run it on a repository that is not this one.** `~/tne/orion` is the obvious candidate. Expect
    the diagnosis to be right and the generated config to need one or two adjustments — capture
    those as generator changes, not local edits.
-3. **Monorepo support**, if a target needs it.
-4. **Python**, after the above.
+2. **Monorepo support**, if a target needs it.
+3. **Python**, after the above.
 
 ## Reference material
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ever-better",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Diagnose a repository, install the quality tooling it is missing, and pin a baseline that can only get better.",
   "keywords": [
     "eslint",


### PR DESCRIPTION
## Summary

Version bump and a HANDOFF refresh. JS → TS migration was the last item from the original scope;
what remains in "not built" was never in it — monorepos and Python.

Publishing 0.4.0 after this merges, so `migrate`, `catalog`, `emit-diff`, the Prettier fix and the
cast ban reach anyone installing from npm or the plugin marketplace.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)