### PR TITLE
docs: size the two remaining directions and link their issues

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -106,8 +106,16 @@ Keep the three-platform matrix. It is the only thing that sees this class of bug
 
 Everything from the original scope has shipped. What remains was never in it:
 
-- **No monorepo support.** One baseline per repository; the state shape leaves room for more.
-- **Python.** Assessed and deferred — see the section above.
+- **No monorepo support.** One baseline per repository — [#30](https://github.com/isamu/ever-better/issues/30).
+  Medium: ESLint's `--suppressions-location` means a per-package ceiling needs no new mechanism, so
+  what is left is workspace discovery and one design decision about the ledger's shape.
+- **Python.** [#31](https://github.com/isamu/ever-better/issues/31). Large but not a rewrite: Ruff
+  owns the primitives, and the ledger, renderer, `check` and ratchet are reusable behind an
+  ecosystem seam. The two hard parts are that Ruff has no external suppressions file (the ceiling
+  lives in the source) and that type checking has no first-party baseline at all.
+
+Both are sized in their issues. Neither is a prerequisite for the other, and both should wait until
+this has been run end to end on a repository that is not this one.
 
 ## The target state
 


### PR DESCRIPTION
## Summary

HANDOFF now carries the sizing for both remaining directions and links the issues.

- **Monorepo — [#30](https://github.com/isamu/ever-better/issues/30), medium.** ESLint takes
  `--suppressions-location`, so a per-package ceiling needs no new mechanism — the part I expected
  to have to invent is solved upstream. What is left is workspace discovery and one design decision:
  one ledger with per-package sections, or one ledger per package.
- **Python — [#31](https://github.com/isamu/ever-better/issues/31), large but not a rewrite.** Ruff
  owns the primitives (`--add-noqa` / `RUF100` / `--fix`), and the ledger, renderer, `check` and the
  whole ratchet are reusable behind an ecosystem seam. The two hard parts: Ruff has **no external
  suppressions file**, so the ceiling lives in the source and the first freeze is an enormous diff;
  and type checking has **no first-party baseline** on either mypy or pyright, so a first release
  should cover linting only.

Both issues say to wait until this has been run end to end on a repository that is not this one.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)