### PR TITLE
feat: var → let → const as a lint rule, and a work log the owner can actually read

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ layers the approach depends on, each covering what the others cannot see:
 | Layer | Tool | What it sees |
 | --- | --- | --- |
 | function size and complexity | ESLint core rules | long functions, deep nesting, too many branches |
+| bindings that move | `no-var`, `prefer-const`, `no-param-reassign` | `var`, a `let` nothing reassigns, an argument overwritten under the caller |
 | types and readability | SonarJS + `strictTypeChecked` | unsafe `any`, cognitive complexity |
 | cross-file duplication | jscpd, into Code Scanning | copy-paste the linter cannot see |
 | dead code | knip | exports nobody imports, orphaned files |

--- a/docs/generated-config.md
+++ b/docs/generated-config.md
@@ -69,6 +69,9 @@ export default tseslint.config(
       "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/no-non-null-assertion": "error",
       "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^__" }],
+      // A private field nothing reassigns is a constant, and saying so stops the next reader
+      // looking for the write that never happens.
+      "@typescript-eslint/prefer-readonly": "error",
       // `as` asserts what the compiler could not check, and it is invisible in review. Write a
       // type guard instead — the guard is testable and the assertion is a promise.
       "@typescript-eslint/consistent-type-assertions": ["error", { assertionStyle: "never" }],
@@ -87,6 +90,19 @@ export default tseslint.config(
     },
   },
   {
+    rules: {
+      // typescript-eslint enables both of these for `.ts` files only, so the JavaScript repo
+      // that actually contains `var` is the one nothing checks — and `.jsx`, `.vue` and `.mjs`
+      // stay uncovered after a migration. `eslint --fix` converts the lot: var -> let, then
+      // let -> const everywhere nothing reassigns.
+      "no-var": "error",
+      "prefer-const": "error",
+      // A reassigned parameter makes the argument name lie for the rest of the function, and
+      // the caller cannot see it happen.
+      "no-param-reassign": "error",
+    },
+  },
+  {
     // Size and complexity guards. These are the ones that turn into refactoring work rather
     // than one-line fixes, which is exactly why they are recorded rather than negotiated.
     rules: {
@@ -97,6 +113,14 @@ export default tseslint.config(
       "max-nested-callbacks": ["error", 4],
       "max-params": ["error", 6],
       "sonarjs/cognitive-complexity": ["error", 15],
+    },
+  },
+  {
+    rules: {
+      // A `return` inside the `if` makes the `else` a level of indentation nobody needs.
+      "no-else-return": ["error", { allowElseIf: false }],
+      // Two `if`s that are one `&&`: a level of nesting for no extra branch.
+      "sonarjs/no-collapsible-if": "error",
     },
   },
   {
@@ -215,6 +239,9 @@ export default tseslint.config(
       "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/no-non-null-assertion": "error",
       "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^__" }],
+      // A private field nothing reassigns is a constant, and saying so stops the next reader
+      // looking for the write that never happens.
+      "@typescript-eslint/prefer-readonly": "error",
       // `as` asserts what the compiler could not check, and it is invisible in review. Write a
       // type guard instead — the guard is testable and the assertion is a promise.
       "@typescript-eslint/consistent-type-assertions": ["error", { assertionStyle: "never" }],
@@ -233,6 +260,19 @@ export default tseslint.config(
     },
   },
   {
+    rules: {
+      // typescript-eslint enables both of these for `.ts` files only, so the JavaScript repo
+      // that actually contains `var` is the one nothing checks — and `.jsx`, `.vue` and `.mjs`
+      // stay uncovered after a migration. `eslint --fix` converts the lot: var -> let, then
+      // let -> const everywhere nothing reassigns.
+      "no-var": "error",
+      "prefer-const": "error",
+      // A reassigned parameter makes the argument name lie for the rest of the function, and
+      // the caller cannot see it happen.
+      "no-param-reassign": "error",
+    },
+  },
+  {
     // Size and complexity guards. These are the ones that turn into refactoring work rather
     // than one-line fixes, which is exactly why they are recorded rather than negotiated.
     rules: {
@@ -243,6 +283,14 @@ export default tseslint.config(
       "max-nested-callbacks": ["error", 4],
       "max-params": ["error", 6],
       "sonarjs/cognitive-complexity": ["error", 15],
+    },
+  },
+  {
+    rules: {
+      // A `return` inside the `if` makes the `else` a level of indentation nobody needs.
+      "no-else-return": ["error", { allowElseIf: false }],
+      // Two `if`s that are one `&&`: a level of nesting for no extra branch.
+      "sonarjs/no-collapsible-if": "error",
     },
   },
   {
@@ -332,6 +380,9 @@ export default tseslint.config(
       "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/no-non-null-assertion": "error",
       "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^__" }],
+      // A private field nothing reassigns is a constant, and saying so stops the next reader
+      // looking for the write that never happens.
+      "@typescript-eslint/prefer-readonly": "error",
       // `as` asserts what the compiler could not check, and it is invisible in review. Write a
       // type guard instead — the guard is testable and the assertion is a promise.
       "@typescript-eslint/consistent-type-assertions": ["error", { assertionStyle: "never" }],
@@ -350,6 +401,19 @@ export default tseslint.config(
     },
   },
   {
+    rules: {
+      // typescript-eslint enables both of these for `.ts` files only, so the JavaScript repo
+      // that actually contains `var` is the one nothing checks — and `.jsx`, `.vue` and `.mjs`
+      // stay uncovered after a migration. `eslint --fix` converts the lot: var -> let, then
+      // let -> const everywhere nothing reassigns.
+      "no-var": "error",
+      "prefer-const": "error",
+      // A reassigned parameter makes the argument name lie for the rest of the function, and
+      // the caller cannot see it happen.
+      "no-param-reassign": "error",
+    },
+  },
+  {
     // Size and complexity guards. These are the ones that turn into refactoring work rather
     // than one-line fixes, which is exactly why they are recorded rather than negotiated.
     rules: {
@@ -360,6 +424,14 @@ export default tseslint.config(
       "max-nested-callbacks": ["error", 4],
       "max-params": ["error", 6],
       "sonarjs/cognitive-complexity": ["error", 15],
+    },
+  },
+  {
+    rules: {
+      // A `return` inside the `if` makes the `else` a level of indentation nobody needs.
+      "no-else-return": ["error", { allowElseIf: false }],
+      // Two `if`s that are one `&&`: a level of nesting for no extra branch.
+      "sonarjs/no-collapsible-if": "error",
     },
   },
   {
@@ -432,6 +504,19 @@ export default tseslint.config(
   { languageOptions: { globals: globals.node } },
 
   {
+    rules: {
+      // typescript-eslint enables both of these for `.ts` files only, so the JavaScript repo
+      // that actually contains `var` is the one nothing checks — and `.jsx`, `.vue` and `.mjs`
+      // stay uncovered after a migration. `eslint --fix` converts the lot: var -> let, then
+      // let -> const everywhere nothing reassigns.
+      "no-var": "error",
+      "prefer-const": "error",
+      // A reassigned parameter makes the argument name lie for the rest of the function, and
+      // the caller cannot see it happen.
+      "no-param-reassign": "error",
+    },
+  },
+  {
     // Size and complexity guards. These are the ones that turn into refactoring work rather
     // than one-line fixes, which is exactly why they are recorded rather than negotiated.
     rules: {
@@ -442,6 +527,14 @@ export default tseslint.config(
       "max-nested-callbacks": ["error", 4],
       "max-params": ["error", 6],
       "sonarjs/cognitive-complexity": ["error", 15],
+    },
+  },
+  {
+    rules: {
+      // A `return` inside the `if` makes the `else` a level of indentation nobody needs.
+      "no-else-return": ["error", { allowElseIf: false }],
+      // Two `if`s that are one `&&`: a level of nesting for no extra branch.
+      "sonarjs/no-collapsible-if": "error",
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,7 +28,20 @@ export default tseslint.config(
       "@typescript-eslint/no-non-null-assertion": "error",
       "@typescript-eslint/consistent-type-assertions": ["error", { assertionStyle: "never" }],
       "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^__" }],
+      "@typescript-eslint/prefer-readonly": "error",
       "no-console": "off",
+    },
+  },
+
+  {
+    rules: {
+      // typescript-eslint enables the first two for `.ts` only, which is why the generator states
+      // them for every file: a `.js`, `.jsx` or `.vue` repo is where `var` actually lives.
+      "no-var": "error",
+      "prefer-const": "error",
+      "no-param-reassign": "error",
+      "no-else-return": ["error", { allowElseIf: false }],
+      "sonarjs/no-collapsible-if": "error",
     },
   },
 

--- a/skills/ever-better-drain/SKILL.md
+++ b/skills/ever-better-drain/SKILL.md
@@ -81,6 +81,12 @@ usually surfaces it:
 **When a fix changes behaviour, that is a bug, and a bug gets a test.** Say so in the commit
 message; do not fold it silently into a lint cleanup.
 
+**A rule ESLint can fix is not this work.** `no-var`, `prefer-const`, `no-else-return`,
+`sonarjs/no-collapsible-if` and Prettier are all fixable: take the whole rule in one command —
+`npx eslint . --fix --rule '{"<rule>":"error"}'` — read the diff, prune, commit. What is left over
+afterwards is the judgment. The `var` the fixer would not touch is the clearest case: it declined
+because a closure or a read outside the block depends on that function scope, which is the bug.
+
 ### 5. Make it testable — extract the pure part
 
 If you cannot write the test without a filesystem, a clock, a network call or a process, the

--- a/skills/ever-better-migrate/SKILL.md
+++ b/skills/ever-better-migrate/SKILL.md
@@ -107,12 +107,23 @@ const isUser = (value: unknown): value is User =>
 It is testable, it narrows for every caller, and it fails at the boundary where the data was
 actually wrong rather than three frames later.
 
-### 6. Regenerate the config and take the baseline
+### 6. Regenerate the config, sweep what the fixer can do, then take the baseline
 
 ```bash
 npx ever-better bootstrap   # regenerate the config, now with the type-aware tier
+npx eslint . --fix          # var -> let -> const, guard clauses, formatting
 npx ever-better freeze --force
 ```
+
+**`--fix` before `freeze`, never after.** Whatever it repairs now never enters the ratchet, and on a
+repository arriving from JavaScript `no-var`, `prefer-const`, `no-else-return` and Prettier are
+usually the largest single block of the backlog. Read the diff — it should contain no behaviour
+change at all — and commit it on its own.
+
+**What the fixer refuses to convert is a finding, not a leftover.** ESLint leaves a `var` alone
+when its function scope is load-bearing: captured by a closure inside a loop, or read outside the
+block it was declared in. Both stay reported. Those are the hoisting bugs `var` is known for, and
+each one is a decision — hand it the block scope it should have had and check what changes.
 
 `--force` is correct here and only here: the rule set genuinely changed, so the ceiling has to be
 re-taken. Say so in the pull request.

--- a/src/generate/eslintConfig.ts
+++ b/src/generate/eslintConfig.ts
@@ -119,6 +119,42 @@ const typedBlock = (options: EslintConfigOptions): string[] => {
 };
 
 /**
+ * Bindings that never move. All three are about a name meaning one thing for its whole scope,
+ * which is the cheapest form of immutability a JavaScript codebase can have — and the first two
+ * are `--fix`-able, so this tier is a command rather than a backlog.
+ */
+const bindingsBlock = (): string[] => [
+  "  {",
+  "    rules: {",
+  "      // typescript-eslint enables both of these for `.ts` files only, so the JavaScript repo",
+  "      // that actually contains `var` is the one nothing checks — and `.jsx`, `.vue` and `.mjs`",
+  "      // stay uncovered after a migration. `eslint --fix` converts the lot: var -> let, then",
+  "      // let -> const everywhere nothing reassigns.",
+  '      "no-var": "error",',
+  '      "prefer-const": "error",',
+  "      // A reassigned parameter makes the argument name lie for the rest of the function, and",
+  "      // the caller cannot see it happen.",
+  '      "no-param-reassign": "error",',
+  "    },",
+  "  },",
+];
+
+/**
+ * Nesting as a shape rather than a measurement. `max-depth` reports that a function is four deep;
+ * these two name the rewrite that removes a level, and both are mechanical.
+ */
+const guardClauseBlock = (): string[] => [
+  "  {",
+  "    rules: {",
+  "      // A `return` inside the `if` makes the `else` a level of indentation nobody needs.",
+  '      "no-else-return": ["error", { allowElseIf: false }],',
+  "      // Two `if`s that are one `&&`: a level of nesting for no extra branch.",
+  '      "sonarjs/no-collapsible-if": "error",',
+  "    },",
+  "  },",
+];
+
+/**
  * Rules that keep the code readable to whoever arrives next, rather than correct. `id-length`
  * carries exceptions because a loop counter and a discarded binding are not the problem it is
  * aimed at — a variable called `d` holding a customer record is.
@@ -162,6 +198,9 @@ const strictnessBlock = (options: EslintConfigOptions): string[] => {
     '      "@typescript-eslint/no-explicit-any": "error",',
     '      "@typescript-eslint/no-non-null-assertion": "error",',
     '      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^__" }],',
+    "      // A private field nothing reassigns is a constant, and saying so stops the next reader",
+    "      // looking for the write that never happens.",
+    '      "@typescript-eslint/prefer-readonly": "error",',
     "      // `as` asserts what the compiler could not check, and it is invisible in review. Write a",
     "      // type guard instead — the guard is testable and the assertion is a promise.",
     '      "@typescript-eslint/consistent-type-assertions": ["error", { assertionStyle: "never" }],',
@@ -251,7 +290,9 @@ export const renderEslintConfig = (options: EslintConfigOptions): string => {
     `  { languageOptions: { globals: ${GLOBALS_EXPRESSION[options.runtime]} } },`,
     "",
     ...strictnessBlock(options),
+    ...bindingsBlock(),
     ...limitsBlock(options),
+    ...guardClauseBlock(),
     ...readabilityBlock(),
     ...testBlock(options),
     ...configFileBlock(options),

--- a/src/probe/effectiveRules.ts
+++ b/src/probe/effectiveRules.ts
@@ -103,6 +103,16 @@ export const HIGH_VALUE_RULES: readonly HighValueRule[] = [
     why: "per-file size; the per-function guards pass while a file reaches 2000 lines",
     setting: '["error", { max: 600, skipBlankLines: true, skipComments: true }]',
   },
+  {
+    name: "no-var",
+    why: "`var` ignores the block it was written in; typescript-eslint enables this for `.ts` files only, so `.js`, `.jsx` and `.vue` go unchecked",
+    setting: '"error"',
+  },
+  {
+    name: "prefer-const",
+    why: "a `let` nothing reassigns hides which values actually move; with `no-var` it is one `--fix` away",
+    setting: '"error"',
+  },
   { name: "complexity", why: "branch count", setting: '["error", 20]' },
   { name: "max-depth", why: "nesting", setting: '["error", 4]' },
   { name: "max-params", why: "argument count", setting: '["error", 6]' },

--- a/test/test_render.ts
+++ b/test/test_render.ts
@@ -282,6 +282,30 @@ describe("renderEslintConfig — readability and security tiers", () => {
     const browser = renderEslintConfig({ ...opts, runtime: "browser" });
     assert.ok(!browser.includes("eslint-plugin-security"));
   });
+
+  it("states no-var and prefer-const itself, because the preset scopes them to .ts", () => {
+    // Measured: typescript-eslint's eslint-recommended block carries both, with
+    // `files: ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"]`. Inheriting them would leave every
+    // .js, .jsx, .vue and .mjs file unchecked — which is exactly the repo that still has `var`.
+    for (const config of [renderEslintConfig(opts), renderEslintConfig({ ...opts, typed: false })]) {
+      assert.match(config, /"no-var": "error"/);
+      assert.match(config, /"prefer-const": "error"/);
+      assert.match(config, /"no-param-reassign": "error"/);
+    }
+  });
+
+  it("asks for the guard clause rather than only measuring the nesting", () => {
+    // max-depth reports that a function is four deep; these two name the rewrite that removes a
+    // level, and both are mechanical. sonarjs ships no-collapsible-if off by default.
+    const config = renderEslintConfig(opts);
+    assert.match(config, /"no-else-return": \["error", \{ allowElseIf: false \}\]/);
+    assert.match(config, /"sonarjs\/no-collapsible-if": "error"/);
+  });
+
+  it("keeps prefer-readonly out of an untyped repo, where it would make every run fatal", () => {
+    assert.match(renderEslintConfig(opts), /"@typescript-eslint\/prefer-readonly": "error"/);
+    assert.ok(!renderEslintConfig({ ...opts, typed: false }).includes("prefer-readonly"));
+  });
 });
 
 describe("renderCodexReviewWorkflow", () => {


### PR DESCRIPTION
## Summary

Two changes, both "write the owner's working rules into the tool rather than into a chat log".

**1. Bindings and guard clauses as lint rules** (commit 1). Encodes the adoptable parts of the Singularity Society
[refactoring guidelines](https://singularitysociety.github.io/societys_statement/development/refactoring.html)
as **lint rules** rather than prose, starting with the one that was actually missing: `var` → `let`
→ `const`.

`no-var` and `prefer-const` were never enforced by anything ever-better generates. They arrive from
typescript-eslint's `eslint-recommended` block, which carries
`files: ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"]` — so a JavaScript repo, which is exactly
the repo that still has `var` in it, was unchecked, and `.jsx`, `.vue` and `.mjs` stayed unchecked
after a migration. The generated config now states them itself.

| Added to the generated config | Why | Fixable |
| --- | --- | --- |
| `no-var` | `var` ignores the block it was written in | yes |
| `prefer-const` | a `let` nothing reassigns hides which values actually move | yes |
| `no-param-reassign` | a reassigned argument makes the parameter name lie, invisibly to the caller | no |
| `@typescript-eslint/prefer-readonly` (typed repos only) | a private field nothing writes is a constant | yes |
| `no-else-return` (`allowElseIf: false`) | the guard clause the page asks for; `max-depth` measures nesting, this removes it | yes |
| `sonarjs/no-collapsible-if` | two `if`s that are one `&&`; off by default in SonarJS | yes |

`no-var` and `prefer-const` are also added to `HIGH_VALUE_RULES`, so `diagnose` reports them as off
and `strengthen` writes them into a config the repo already owns.

**2. The work log becomes a step in every skill** (commit 2, docs only). `QUALITY.md` has a **Work
log** table, and `ever-better log` is the only thing that writes it — `freeze`, `prune` and `check`
record counts, never the reason behind one. Only the `run` skill said so, so a drain could leave an
owner a falling number and no account of what it cost.

The doctrine now sits once in the router skill — one entry per commit as it is made, written for
the person who was not watching, covering the choices as well as the fixes — and each work skill
logs at its own step:

| Skill | Logs |
| --- | --- |
| `drain` | per rule drained, and per rule walked past (`issue` / `deferred`) |
| `dry` | the clone deliberately **not** extracted — the extraction is in the diff, the judgement is not |
| `bootstrap` | which tiers went on, and which stayed off and why — the ceiling is a number from exactly that rule set |
| `migrate` | the migration's cost, and why `freeze --force` was legitimate rather than covering up a red build |

Verified against the built CLI: `log --kind note "…"` works without `--rule`, and both entries
render into the table newest-first.

## Items to Confirm / Review

- **`strengthen` gets two of the six, not all six.** It edits a config someone else wrote, so it
  adds what is a defect to be missing (`no-var`, `prefer-const`) rather than the whole house style.
  The other four ship only in the config `bootstrap` generates. Reasonable line, or should
  `no-param-reassign` cross it too?
- **`no-param-reassign` is not `--fix`-able and is the one that can be noisy** — a `reduce`
  accumulator pattern trips it. It is set without `props`, so only rebinding the parameter itself is
  reported, not mutating an object it points at. `freeze` grandfathers whatever exists.
- **`sonarjs/no-collapsible-if` is off in SonarJS's own recommended set**, so this turns a rule on
  that its authors chose not to. It is the page's 「深いネストを浅く」 stated as a shape.
- **Sizes deliberately unchanged.** The page says 1 function ≤ 20 lines / 1 file ≤ 400; the
  generator stays at 50 / 600. Discussed and kept — 20 is a guideline the page itself calls 目安,
  and it collides with ever-better's own 60 / 300.
- **`--fix` before `freeze` in the migrate skill**: the ordering matters and nothing enforces it.
- **The work log stays a discipline, not a gate.** Nothing fails when an agent skips an entry, and
  `check` has no opinion about it. Making it enforceable — say, `prune` refusing without a matching
  entry — would be a real change and is deliberately not in this PR.

## User Prompt

- ts化、もしくは refactoring するときに、var は全部 let に置換し、できる限り const に置き換えて
  immutable にする、を追加して。
- つまり、このへん（https://singularitysociety.github.io/societys_statement/development/refactoring.html）
  で取り入れられるものは書いておいて。できる限り。
- eslint や ts の rule でね。
- ユーザがなにやったか把握できるように、細かく作業ログをかいていく、と追加したほうが良いかもね。

## Verified against real ESLint, not by reading docs

Both configs were rendered by `renderEslintConfig` into a scratch fixture and linted with the real
binary:

| Fixture | Reported |
| --- | --- |
| `bad.js` (untyped config) | `no-var`, `prefer-const`, `no-param-reassign` |
| `bad.ts` (typed config) | `no-var`, `prefer-const`, `@typescript-eslint/prefer-readonly`, no fatal from the type program |
| `more.js` | `no-else-return`, `sonarjs/no-collapsible-if` |

`eslint --fix` then turned `var legacyName = 1` into `const legacyName = 1` in a single pass.

**The fixer is conservative, and that turned out to be the interesting part.** It refused two of
them: a `var` captured by a closure inside a loop, and a `var` read outside the block it was
declared in. Both stay reported as errors. Those are the hoisting bugs `var` is known for, so what
the fixer leaves behind is a finding rather than a leftover — which is what the skills now say.

## What of the page was already covered

Only the six rules above were missing. Recorded here so the next reader does not go looking:

| Page principle | Already in ever-better |
| --- | --- |
| 小さく保つ（関数・ファイル） | `max-lines`, `max-lines-per-function`, `complexity`, `max-depth`, `sonarjs/cognitive-complexity` |
| 型（`any` を避ける） | `no-explicit-any`, `strictTypeChecked`, the `as` / `!` / `@ts-ignore` ban |
| DRY・コピペ検出 | `sonarjs/no-identical-functions`, jscpd into Code Scanning, the `dry` skill |
| 要らない抽象を削る（YAGNI） | knip |
| テストできる形に書く・依存性注入 | `ever-better-drain` step 5 (decision / effect split, pass what varies as an argument) |
| Prettier で整形の議論をなくす | Prettier runs as a lint rule, inside the ratchet |
| CI が通らなければマージをブロック | the generated three-platform workflow |
| ルールは最初ゆるく、少しずつ厳しく | the ratchet itself — `freeze`, then `prune` |
| 鍵の直書き | `sonarjs/no-hardcoded-secrets` / `-passwords` / `hardcoded-secret-signatures`, plus eslint-plugin-security |
| 疎結合（依存の向き） | **no rule.** Import-cycle detection is deliberately absent — the reason is in `eslintConfig.ts` |

## Checks

`yarn format` / `lint` / `typecheck` / `build` all clean; `yarn test` 239 passing, including four
new cases in `test/test_render.ts`. `docs/generated-config.md` regenerated with `yarn docs`.
ever-better's own `eslint.config.js` runs all six and reports nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in ever-better
