### PR TITLE
docs: make the work log a step in every skill, not only the unattended one

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,9 @@ ever-better log --kind deferred --rule max-lines "router.ts is 1400 lines; its o
 ever-better log --kind issue    --rule no-floating-promises "opened #42 — product decision"
 ```
 
-Records what happened against the current commit. `deferred` is the one that earns its keep: it
-renders into a **Carried over** checklist in `QUALITY.md` with the commit it was seen at, because
+Records what happened against the current commit, and it is the only thing that writes the **Work
+log** in `QUALITY.md` — every other command records counts, never why. `deferred` is the one that
+earns its keep: it renders into a **Carried over** checklist with the commit it was seen at, because
 "router.ts needs splitting" is useless four hundred commits later unless a reader can tell when it
 was true.
 

--- a/skills/ever-better-bootstrap/SKILL.md
+++ b/skills/ever-better-bootstrap/SKILL.md
@@ -106,6 +106,14 @@ block the freeze.
 
 ### 7. Hand off
 
+```bash
+npx ever-better log --kind note "eslint 8 -> 10, sonarjs + security tiers on; max-lines-per-function left at 60 for a scripts repo"
+```
+
+Record what you turned on and, more importantly, **what you turned off and why** — the ceiling
+frozen next is a number from exactly this rule set, and a tier missing for a reason is
+indistinguishable later from a tier nobody got to.
+
 Say how many violations there are and across how many rules, then route to the
 **`ever-better-freeze`** skill. Do not freeze here — freezing is a decision, and the user should
 make it having seen the number.

--- a/skills/ever-better-drain/SKILL.md
+++ b/skills/ever-better-drain/SKILL.md
@@ -198,10 +198,20 @@ of it.
 **Never run `freeze` here.** It would re-pin the ceiling at today's number and quietly forgive
 anything added since. It refuses by design; `--force` is not the answer to a red build.
 
-### 8. Commit and open the PR
+### 8. Record what the rule cost, then commit and open the PR
 
-One rule, and say in the body: the rule, how many violations it removed, the ceiling before and
-after, and **every behaviour change with its test**. A reviewer needs to separate "renamed a
+```bash
+npx ever-better log --kind drained --rule <rule> "12 violations; 1 real bug — parseDate returned undefined for an empty string"
+```
+
+Numbers are recorded for you; **what you found is not**. Write the entry as you finish the rule and
+before the commit, not in a batch at the end — each is stamped with whatever is HEAD at that moment,
+which is the only thing that makes an old entry re-checkable. It renders into the **Work log** in
+`QUALITY.md`, which is what an owner who was not watching reads before any diff, so it wants the
+rule, the count, and the one thing worth knowing rather than "fixed max-depth".
+
+One rule per PR, and say in the body: the rule, how many violations it removed, the ceiling before
+and after, and **every behaviour change with its test**. A reviewer needs to separate "renamed a
 variable" from "this was returning undefined".
 
 **When the edit re-indents a block, that is two commits, not one.** Wrapping a body in a guard, a
@@ -226,6 +236,15 @@ Open a GitHub issue — do not guess — when the fix requires a decision only t
 
 Write the issue with: the rule, the file and line, what the two or three options are, and what you
 would pick and why. Then move to the next rule rather than blocking.
+
+```bash
+npx ever-better log --kind issue --rule <rule> "opened #42 — swallowed error, product decision"
+```
+
+**A rule you walked past needs an entry as much as one you drained** — `issue` for what became
+somebody's decision, `deferred` for what you looked at and chose to leave. Without one the ledger
+shows a backlog that stopped moving and no reason why, which reads as an unattended run that quietly
+gave up.
 
 Everything else — a missing await, a narrowed type, a validated response, an extracted function, a
 new test — you do, without asking.

--- a/skills/ever-better-dry/SKILL.md
+++ b/skills/ever-better-dry/SKILL.md
@@ -158,3 +158,12 @@ Open one rather than guessing when:
 
 Say which clones, what you would extract, where you would put it, and what it would cost. Then move
 on to the next one instead of waiting.
+
+```bash
+npx ever-better log --kind deferred "3 clones between server/ and web/; extracting crosses the package boundary — #47"
+```
+
+**A clone you decided to leave needs the entry more than one you extracted.** The extraction is in
+the diff; the judgement that two similar blocks are coincidence rather than one idea is visible
+nowhere else, and the next run will otherwise re-open the same question and reach a different
+answer.

--- a/skills/ever-better-migrate/SKILL.md
+++ b/skills/ever-better-migrate/SKILL.md
@@ -126,7 +126,13 @@ block it was declared in. Both stay reported. Those are the hoisting bugs `var` 
 each one is a decision — hand it the block scope it should have had and check what changes.
 
 `--force` is correct here and only here: the rule set genuinely changed, so the ceiling has to be
-re-taken. Say so in the pull request.
+re-taken. Say so in the pull request — and in the ledger, which is where the next session looks:
+
+```bash
+npx ever-better log --kind note "migrated 214 files; 37 type errors fixed; strict:false for now, flags priced in #51; freeze --force because the rule set changed"
+```
+
+A `--force` nobody explained looks exactly like a `--force` used to make a red build green.
 
 Then delete `allowJs` and `checkJs` from the tsconfig — with no `.js` left, both are dead
 configuration that will confuse the next reader.

--- a/skills/ever-better-run/SKILL.md
+++ b/skills/ever-better-run/SKILL.md
@@ -27,10 +27,18 @@ Record as you go, not at the end:
 npx ever-better log --kind drained  --rule max-depth "6 violations, 1 real bug (unreachable branch)"
 npx ever-better log --kind deferred --rule max-lines "server/router.ts is 1400 lines; splitting is its own project"
 npx ever-better log --kind issue    --rule no-floating-promises "opened #42 — swallowed error, product decision"
+npx ever-better log --kind note "eslint 8 -> 10 before freezing; the ceiling is from the new rule set"
 ```
 
 The commit stamp is the point. A note saying "router.ts needs splitting" is useless six months and
 four hundred commits later unless a reader can see when it was true.
+
+**Nothing writes these for you, and in this mode nobody else can.** The counts are recorded by
+`freeze` and `prune`; every reason behind them exists only if you write it. One entry per commit as
+you make it — a batch at the end stamps them all with the wrong commit — and one for each decision
+as well as each fix, including the tier you left off and the clone you chose not to extract. This
+table is the first thing the owner reads when they come back to a stack of pull requests, so it is
+worth writing as if it were the only thing they read.
 
 ## Coming back to a repository you have not touched in a while
 

--- a/skills/ever-better/SKILL.md
+++ b/skills/ever-better/SKILL.md
@@ -46,6 +46,31 @@ numbers. Re-read it between steps and name the step you are starting. An agent w
 does not stop; it quietly merges two steps, drops the verification in the middle, and reports a
 phase complete that was never run.
 
+## Leave a trail the owner can read
+
+**Nothing writes the work log for you.** `freeze`, `prune` and `check` record counts; what a count
+cost and what it uncovered exists only because somebody wrote it down:
+
+```bash
+npx ever-better log --kind drained  --rule max-depth "12 violations; 1 real bug — unreachable branch, deleted with a test"
+npx ever-better log --kind deferred --rule max-lines "router.ts is 1400 lines; splitting it is its own project"
+npx ever-better log --kind issue    --rule no-floating-promises "opened #42 — swallowed error, product decision"
+npx ever-better log --kind note "ESLint 8 -> 9 before freezing, so the ceiling is from the new rule set"
+```
+
+The last twenty entries render as the **Work log** table in `QUALITY.md`, and `deferred` also
+becomes a **Carried over** checklist.
+
+- **One entry per commit, written as you make it.** Each is stamped with whatever is HEAD at that
+  moment, which is what lets a later reader ask whether an old note still describes the code — and
+  what a batch written at the end gets wrong for every entry except the last.
+- **Write it for the person who was not watching.** An owner returning to six pull requests reads
+  this table before the diffs. "fixed max-depth" tells them nothing a diff would not; the rule, the
+  count, and the one thing worth knowing — the bug, the decision, the surprise — is the whole value.
+- **Log the choices too, not only the work.** A tier left off, a dependency left at its old major,
+  a clone deliberately not extracted: `note` and `deferred` exist so a decision is legible later as
+  a decision, rather than looking like something nobody got to.
+
 ## Dependencies: tooling early, breaking changes once the tests can catch them
 
 Two halves, and the split is about what can tell you when something broke:


### PR DESCRIPTION
## Summary

Documentation only — README plus six `SKILL.md` files. This is the second commit from the PR #35
branch; #35 was merged at its first commit, so this carries the rest.

`QUALITY.md` has a **Work log** table, and `ever-better log` is the only thing that writes it —
`freeze`, `prune` and `check` record counts, never the reason behind one. Only the `run` skill said
so, so a drain could leave an owner a falling number and no account of what it cost.

The doctrine now sits once in the router skill — one entry per commit as it is made, written for the
person who was not watching, covering the choices as well as the fixes — and each work skill logs at
its own step:

| Skill | Logs |
| --- | --- |
| `drain` | per rule drained, and per rule walked past (`issue` / `deferred`) |
| `dry` | the clone deliberately **not** extracted — the extraction is in the diff, the judgement is not |
| `bootstrap` | which tiers went on, and which stayed off and why — the ceiling is a number from exactly that rule set |
| `migrate` | the migration's cost, and why `freeze --force` was legitimate rather than covering up a red build |
| `run` | already said "record as you go"; now says who the reader is |

## Items to Confirm / Review

- **It stays a discipline, not a gate.** Nothing fails when an agent skips an entry, and `check` has
  no opinion about it. Making it enforceable — `prune` refusing without a matching entry, say —
  would be a real behaviour change and is deliberately not here.
- **Some repetition across skills is on purpose.** Each is loaded on its own, so a `drain` agent may
  never read the router. The full doctrine is in the router; the work skills carry one line each.
- **Whether `bootstrap` should log at all** is the weakest of the five — what it installed is
  visible in the diff. It is in for the tier deliberately left *off*, which is not.

## User Prompt

- ユーザがなにやったか把握できるように、細かく作業ログをかいていく、と追加したほうが良いかもね。

（前段の依頼: ts化・refactoring 時に `var` を `let` へ、できる限り `const` にして immutable にする
ルールを追加。取り入れられるものは、できる限り ESLint / TS の rule として書く。→ PR #35 でマージ済み。）

## Verified

Against the built CLI rather than by reading the source: `ever-better log --kind note "…"` is
accepted without `--rule`, and entries render into the **Work log** table newest-first with their
commit stamp.

`yarn format` / `lint` / `test` all clean (239 passing) — no source file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in ever-better
