### PR TITLE
docs: lead with the Claude Code path, not the CLI

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -10,23 +10,26 @@
 
 既存のコードベースを、**良くなる方向にしか動かない**状態にするツール。
 
-リポジトリを指定すると、足りない品質ツールを診断して導入し、その時点の違反件数を「天井」として記録します。そのコミット以降、既存コードは免除され、新しく書いたコードだけが全ルールの対象になります。天井は下がることはあっても上がりません。
+足りない品質ツールを診断して導入し、その時点の違反件数を「天井」として記録します。そのコミット以降、既存コードは免除され、新しく書いたコードだけが全ルールの対象になります。天井は下がることはあっても上がりません。
 
-```bash
-npx ever-better diagnose     # 読み取りのみ: 何が足りないか、それが何を意味するか
-npx ever-better bootstrap    # 導入して設定ファイルを生成
-npx ever-better freeze       # 今日の違反件数を天井として固定
-npx ever-better check        # CI のゲート: 件数が増えたら失敗
-npx ever-better prune        # 直した分だけ天井を下げる
+## 使い方: リポジトリごと Claude Code に渡す
+
+これが主役の使い方です。プラグインの導入は最初の1回だけ、どの Claude Code セッションからでも構いません:
+
+```
+/plugin marketplace add isamu/ever-better
+/plugin install ever-better
 ```
 
-## Claude Code に丸投げする
-
-こちらが本来の使い方です。プラグインを入れて、Claude Code をリポジトリに向けてこう言うだけ:
+あとは、良くしたいリポジトリに `cd` して、**そこで** Claude Code を起動し、こう言うだけです:
 
 ```
 このレポに ever-better を回して
 ```
+
+準備はこれで全部です。対象リポジトリ側に事前設定は要りませんし、CLI を自分で入れる必要もありません（スキルが `npx` 経由で呼びます）。
+
+### この一言で何が起きるか
 
 診断し、足りないものを導入し、フォーマットし、ベースラインを固定し、そこから**1ルール = 1 PR**でバックログを削っていきます。違反を直し、直すために必要な pure 関数を切り出し、テストを書き、天井を下げながら進みます。
 
@@ -34,14 +37,24 @@ npx ever-better prune        # 直した分だけ天井を下げる
 
 届く PR の順番: フォーマット → ツール導入 → freeze → 以降1ルールずつ。手つかずのリポジトリなら数本では済みません。始める前に知っておく価値があります。
 
-```
-/plugin marketplace add isamu/ever-better
-/plugin install ever-better
-```
+### 全部ではなく一部だけ頼む
 
-スキルは `ever-better-run`（上の無人ループ）、`ever-better`（入口とルーティング）、`ever-better-bootstrap`、`ever-better-freeze`、`ever-better-drain`、`ever-better-dry`。
+上の一言は「無人で全部」の起動です。もっと狭く頼めば、その範囲のスキルに自動で振り分けられます（スキル名を自分で指定する必要はありません）:
 
-以下の CLI はこれらのスキルが呼ぶものですが、自分で動かしたい場合はそれだけでも使えます。
+| こう言うと | こうなる |
+| --- | --- |
+| 「このレポに ever-better を回して」「きれいにして」「全部やっておいて」 | 全工程を無人で — `ever-better-run` |
+| 「この repo の品質を上げたい」「何から手を付ければいい？」 | 診断してフェーズごとに案内 — `ever-better` |
+| 「CLAUDE.md を整えて」「規約を追加して」 | `ever-better-prepare` |
+| 「TypeScript にしたい」「ts化して」 | `ever-better-migrate` |
+| 「lint を入れて」「eslint 設定して」 | `ever-better-bootstrap` |
+| 「ベースラインを固定して」「既存のエラーは許して新しいのだけ止めたい」 | `ever-better-freeze` |
+| 「バックログを潰して」「リファクタリングして」 | `ever-better-drain` |
+| 「重複を消して」「dead code を消して」 | `ever-better-dry` |
+
+### この README を読ませるのとは別物です
+
+このページを Claude Code に読ませても、渡るのはコマンドだけで、**プロセスは渡りません** — この違反は本物のバグか、直すべきか issue にすべきか、どこで止まって聞くべきか、work log に何を書くか。その部分はスキルにあり、スキルはプラグインで入ります。
 
 ## なぜ必要か
 
@@ -53,7 +66,17 @@ ESLint はこれを本体の **bulk suppressions** で解決しました。`--su
 
 ratchet の再実装はしていません。linter でもありません。**あなたの** ESLint を、**あなたの** 設定で実行します。
 
-## インストール
+## CLI を自分で叩く
+
+上のスキルが呼んでいるのがこの CLI です。自分で動かしたい場合はそれだけでも使えます。
+
+```bash
+npx ever-better diagnose     # 読み取りのみ: 何が足りないか、それが何を意味するか
+npx ever-better bootstrap    # 導入して設定ファイルを生成
+npx ever-better freeze       # 今日の違反件数を天井として固定
+npx ever-better check        # CI のゲート: 件数が増えたら失敗
+npx ever-better prune        # 直した分だけ天井を下げる
+```
 
 ```bash
 npm install -g ever-better     # npx でも、yarn add --dev でも可
@@ -182,10 +205,6 @@ ever-better emit-diff --against main
 | `QUALITY.md` | 台帳から描画 | する — 人間向けのビュー |
 
 `QUALITY.md` は毎回再生成され、台帳から描画された4つのセクションを持ちます: フェーズをチェックボックスにし残件の少ないルールを子項目にした **Worklist**、意図的に見送ったリファクタリングの **Carried over**、**Ratchet** 表、そして **Work log**。`<!-- ever-better:notes:start -->` マーカーの間に書いたものは保持されます。
-
-## Claude Code プラグイン
-
-冒頭に書いたとおり、プラグインが主役で CLI はそれが呼ぶ道具です。この分担は意図的なもので、CLI は毎回同じ結果でなければならない作業（検出・導入・集計・描画・ゲート）を、スキルは判断が要る作業（この警告は本物のバグか、これは重複か偶然か、何を issue にすべきか）を担当します。
 
 ## フェーズ
 

--- a/README.md
+++ b/README.md
@@ -10,25 +10,29 @@ English | [日本語](README.ja.md)
 
 Make an existing codebase one that can **only get better**.
 
-Point it at a repository. It reports what quality tooling is missing, installs it, and records
-every violation that exists today as a ceiling. From that commit on, old code is grandfathered and
-new code is held to the whole rule set — and the ceiling can fall but never rise.
+It reports what quality tooling a repository is missing, installs it, and records every violation
+that exists today as a ceiling. From that commit on, old code is grandfathered and new code is held
+to the whole rule set — and the ceiling can fall but never rise.
 
-```bash
-npx ever-better diagnose     # read-only: what is missing, and what each gap costs
-npx ever-better bootstrap    # install it, generate the configs
-npx ever-better freeze       # pin today's violations as the ceiling
-npx ever-better check        # CI gate: fail if anything rose
-npx ever-better prune        # after a fix: reclaim the ceiling you earned
+## How to use it: hand a repository to Claude Code
+
+This is the primary interface. Install the plugin once, from any Claude Code session:
+
+```
+/plugin marketplace add isamu/ever-better
+/plugin install ever-better
 ```
 
-## Hand it to Claude Code
-
-This is how it is meant to be used. Install the plugin, point Claude Code at a repository and say:
+Then `cd` into the repository you want improved, start Claude Code **there**, and say:
 
 ```
 run ever-better on this repo
 ```
+
+That is the whole setup. The target repository needs nothing prepared in advance, and you do not
+have to install the CLI — the skills reach it through `npx`.
+
+### What that one sentence does
 
 It diagnoses, installs what is missing, formats, freezes the baseline, then works the backlog down
 one rule per pull request — fixing violations, extracting the pure functions that make the fixes
@@ -42,15 +46,27 @@ be wrong for this repo. Each issue names the options and which one it would pick
 What arrives, in order: a formatting PR, a tooling PR, a freeze PR, then one PR per rule. On an
 untouched repository that is more than a handful — worth knowing before you start it.
 
-```
-/plugin marketplace add isamu/ever-better
-/plugin install ever-better
-```
+### Asking for less than the whole thing
 
-The skills are `ever-better-run` (the unattended loop above), `ever-better` (entry point and
-routing), `ever-better-bootstrap`, `ever-better-freeze`, `ever-better-drain`, `ever-better-dry`.
+The sentence above starts the unattended run. Ask for something narrower and it routes to the skill
+that covers it — you never name a skill yourself:
 
-The CLI below is what those skills call, and it works on its own if you would rather drive.
+| What you say | What runs |
+| --- | --- |
+| "run ever-better on this repo", "clean this repo up" | the whole process, unattended — `ever-better-run` |
+| "what would ever-better do here", "where do I start with this codebase" | diagnose and route one phase at a time — `ever-better` |
+| "set up the conventions", "CLAUDE.md を整えて" | `ever-better-prepare` |
+| "migrate this to TypeScript", "ts化して" | `ever-better-migrate` |
+| "set up linting here", "lint を入れて" | `ever-better-bootstrap` |
+| "freeze the baseline", "grandfather the existing violations" | `ever-better-freeze` |
+| "drain the backlog", "リファクタリングして" | `ever-better-drain` |
+| "remove the duplication", "dead code を消して" | `ever-better-dry` |
+
+### Reading this README to an agent is not the same thing
+
+Pointing Claude Code at this page gives it the commands, not the process — which violation is a
+real bug, what deserves an issue rather than a fix, when to stop and ask, what belongs in the work
+log. That part is the skills, and the skills arrive with the plugin.
 
 ## Why this exists
 
@@ -67,7 +83,17 @@ them, keeping a readable ledger of where you started, and failing CI when a numb
 
 It does not reimplement the ratchet. It is not a linter. It runs *your* ESLint, with *your* config.
 
-## Install
+## Driving the CLI yourself
+
+The skills above call this CLI, and it works on its own if you would rather drive.
+
+```bash
+npx ever-better diagnose     # read-only: what is missing, and what each gap costs
+npx ever-better bootstrap    # install it, generate the configs
+npx ever-better freeze       # pin today's violations as the ceiling
+npx ever-better check        # CI gate: fail if anything rose
+npx ever-better prune        # after a fix: reclaim the ceiling you earned
+```
 
 ```bash
 npm install -g ever-better     # or run it with npx, or yarn add --dev ever-better
@@ -245,13 +271,6 @@ but the gap list, the file sizes and every deferred note do.
 **Worklist** of phases as checkboxes with the smallest remaining rules as sub-items, **Carried
 over** for refactors deliberately not made, the **Ratchet** table, and a **Work log**. Anything you
 write between the `<!-- ever-better:notes:start -->` markers survives.
-
-## Claude Code plugin
-
-Covered at the top — the plugin is the primary interface, and the CLI is what it calls. The split
-is deliberate: the CLI does what must be identical on every run (detect, install, count, render,
-gate), and the skills do what needs judgment (is this warning a real bug, is this duplication or
-coincidence, what deserves an issue).
 
 ## The phases
 


### PR DESCRIPTION
## Summary

The plugin is the primary interface, but `README.md` opened with a block of `npx` commands. A reader following the page top to bottom drove the CLI by hand and never reached the skills — which is where the judgment part of the process lives.

This reorders both READMEs so the Claude Code path is the first thing after the tagline: install the plugin, `cd` into the target repository, say one sentence. The CLI moves down to "Driving the CLI yourself", merged with the old Install section.

Documentation only. No source file changed.

## Items to Confirm / Review

1. **The routing table is the new content, and it is a claim about behaviour.** Each row says what a user can type to reach a given skill. The phrasings were taken from the `description:` frontmatter of the eight `SKILL.md` files, so they should route — but routing is the model's judgement, not a lookup, and I have not exercised all eight end to end.
2. **"Reading this README to an agent is not the same thing" is a new section.** It exists because that was the assumption that prompted this PR. If you would rather the page did not spend a paragraph on what it *isn't*, it is the first thing to cut.
3. **The old `## Claude Code plugin` section near the bottom is deleted**, not moved — its content was two sentences restating the top and the `## Design` section. Nothing else links to it.
4. **`README.ja.md` is restructured to match**, section for section. The Japanese wording of the routing table uses the Japanese trigger phrases from the same skill descriptions, so the two tables are not literal translations of each other.

## User Prompt

- これの使い方って、対象のレポジトリを checkout している dir で Claude Code を起動して README を読んでコードを改善して、みたいな使い方を想定しているけど合っている？
- もしそうなら README をまずそれが全面に出るように書き換えて。

The premise was half right — the target directory is correct, pointing the agent at this page is not — so the rewrite leads with the plugin route and says explicitly why the README-only route is different.

## What changed

**`README.md` / `README.ja.md`** — same restructure in both:

- new `## How to use it: hand a repository to Claude Code` immediately after the tagline: `/plugin marketplace add` → `/plugin install` → `cd` → "run ever-better on this repo"
- `### What that one sentence does` — the existing description of the unattended run, unchanged
- `### Asking for less than the whole thing` — new table mapping what the user says to each of the eight skills
- `### Reading this README to an agent is not the same thing` — new, short
- `## Driving the CLI yourself` — the `npx` block from the old top, plus the old `## Install` section
- `## Claude Code plugin` — deleted

## Verification

- `grep -rn README src test scripts docs .github` → no hits; nothing reads or asserts on these files
- `*.md` is in `.prettierignore`, so `format:check` is unaffected

work in ever-better