### PR TITLE
docs(drain): the order to take the rules in, and what to check first

### DIFF
--- a/skills/ever-better-drain/SKILL.md
+++ b/skills/ever-better-drain/SKILL.md
@@ -10,12 +10,33 @@ where the number comes down and the bugs come out.
 **Automate by default.** The only things that stop and ask are the ones where a wrong guess costs
 the owner real work — see "What becomes an issue" below. Everything else you fix, test and commit.
 
-## Before the loop: is this repository typed yet?
+## Before the loop
 
-If it is still JavaScript, stop and run **`ever-better-migrate`** first. Refactoring untyped code is
-done blind — the tier that finds the real bugs cannot run, so nothing but the tests disagrees with
-you — and every rename surfaces its type errors *after* the move, which changes the shape of what
-you just extracted. Migrate, then run the linter, read what it reports, and let that pick the work.
+Three questions, and each one changes the order you would otherwise work in — or says the backlog
+you are about to drain is not the real one.
+
+**Is this repository typed yet?** If it is still JavaScript, stop and run **`ever-better-migrate`**
+first. Refactoring untyped code is done blind — the tier that finds the real bugs cannot run, so
+nothing but the tests disagrees with you — and every rename surfaces its type errors *after* the
+move, which changes the shape of what you just extracted. Migrate, then run the linter, read what it
+reports, and let that pick the work.
+
+**Is the linter looking at the whole repository?** Worth asking whenever the repo brought its own
+ESLint config, because `bootstrap` never overwrites one — and a ceiling pinned over half a
+repository is not a ceiling. Three separate things pin the scope and fixing one alone changes
+nothing: `ignores` in the config, the **path argument** in the lint script (`eslint src` overrules
+whatever the config thinks about `backend/`), and any wrapper that calls something else again — a
+Makefile target, a CI step, a `|| true`. Ignore globs mislead the same way: `dist/**` without a
+leading `**/` matches the repo root only, so a nested `packages/*/dist` was never excluded. Do not
+read this off the config. Put one deliberate violation in each top-level source directory, run the
+repo's own lint command, and see which ones report it.
+
+**Is part of the backlog dead code?** A finding in a file nothing imports costs exactly what a real
+one costs and buries it in the list — in one frontend, a fifth of the files were unreachable from
+the entry point and carried 78 of the 555 findings. `knip` already ran in bootstrap: take its
+orphans first, because deleting a file removes findings with no fix for anyone to review.
+Reachability is computed by resolving import specifiers, never by grepping for the basename — a
+component named only inside a JSX comment reads as reachable to grep.
 
 ## The loop
 
@@ -27,17 +48,44 @@ asserts the code you just wrote. `ever-better status` and the worklist in `QUALI
 checklist — re-read them between steps rather than carrying the position in your head, which is how
 a step gets skipped and reported as done.
 
-### 1. Pick the rule
+### 1. Pick the rule — and the order to take them in
 
 ```bash
 npx ever-better status
 ```
 
-It lists the **smallest** remaining backlogs first. Take the top one, unless the user named a rule.
+It lists the **smallest** remaining backlogs first. Small first is deliberate: suppressions are
+recorded per file, so every file you take to zero is locked by `prune` on the way past, and a rule
+with no entries left can never come back at all. A half-drained large rule protects only the files
+already finished.
 
-Small first is deliberate: a rule that reaches zero is a rule that can never come back, because
-`prune` removes its last suppression and `check` then rejects the next one. A half-drained large
-rule protects nothing.
+Within that, cheapest and most durable first. This order was arrived at the long way, by draining a
+1,200-warning repository down rule by rule:
+
+1. **What the fixer can take.** `npx eslint . --fix --rule '{"<rule>":"error"}'`, one rule at a
+   time, and `--report-unused-disable-directives` in the same pass — `eslint-disable` comments rot,
+   and the ones that no longer suppress anything come out with the same command. No judgment, no
+   behaviour change, several rules to zero in an afternoon.
+2. **The rules whose count is a config bug rather than a code bug.** A large count with one uniform
+   shape is a config smell: find out what the rule's options actually resolve to before editing a
+   single site. 64 of one repo's 163 `no-unused-vars` findings were an `argsIgnorePattern` written
+   `^(_|e|err)$` — the `$` anchors the whole name, so it matched a bare `_` and nothing else — plus
+   caught errors, which ESLint 9 routes through `caughtErrors` and not through the args pattern at
+   all. `eslint --print-config <file>` answers this. Reading the config source does not.
+3. **The singletons, in one pass.** One rule per PR is the rule below, and a dozen rules holding one
+   or two findings each is where it costs more than it buys. Take them together and name in the body
+   which rules went to zero.
+4. **The small rules, one per PR.** The loop below, in the order `status` prints them.
+5. **The big rules by directory, not by rule.** Several hundred violations is not a pull request.
+   Split by directory and take them in the order a mistake there reaches furthest — startup, shared
+   libraries, auth and middleware ahead of leaf handlers and view components. An `any` in what
+   everything imports is not the same finding as an `any` in one route.
+6. **The refactor rules last** — cognitive complexity, nested conditionals, function and file
+   length. Every finding is a redesign rather than an edit, which is why most of what becomes an
+   issue comes from here. Reaching them last also means reaching them after the extractions in
+   steps 5 and 6c have already taken some of the count away.
+
+Take the top one, unless the user named a rule.
 
 ### 2. See the actual violations
 


### PR DESCRIPTION
## Summary

`ever-better-drain` said "smallest backlog first" and stopped there. That is right, and it is not the whole order — it says nothing about which *kind* of work is cheap, and nothing about the two things that make the backlog itself wrong before any of it starts.

This adds both, distilled from watching a real repository with ~1,200 warnings drained rule by rule to the point where the remaining rules were all refactors. Documentation only — one `SKILL.md`, no source file changed.

## Items to Confirm / Review

1. **The ordering is experience, not measurement.** It is one repository's drain, generalised. The strongest claim in it — that a large count with a uniform shape is usually a config bug rather than a code bug — was worth 64 of 163 findings there, and I have no second data point.
2. **"Check the linter's scope first" partly belongs to `ever-better-freeze`**, not here: freezing over a tree the linter never looks at pins a ceiling that is not the repo's ceiling. It is in the drain skill because that is where the ordering lives, and because `bootstrap` writes `eslint .` so it only bites on repos that brought their own config. Say the word and the freeze skill gets its own version.
3. **The dead-code check reorders two phases.** It tells drain to take `knip`'s orphans before draining, which reads as P5 work arriving in P3. The reason is that a finding in an unreachable file costs exactly what a real one costs and hides it in the list — deleting the file removes findings with no fix to review. If you would rather the phases stayed clean, this is the paragraph to cut.
4. **The `no-unused-vars` example names ESLint 9 behaviour** (`caughtErrors` no longer routing through `argsIgnorePattern`). Verified against the docs for the version this tool installs, not against every intermediate release.

## Verification

`--fix` with `--report-unused-disable-directives` really does remove a stale directive — run against this repo's own ESLint 10.8.1 on a scratch fixture rather than taken from the docs:

```
// eslint-disable-next-line no-var     ->   (removed, blank line left behind)
let a = 1;
```

`grep -rln "skills/" test/ src/ scripts/` → no hits; nothing asserts on skill content.

## User Prompt

- eslint の warn とかってどういう順で減らしていけばよいか、実際に drain したリポジトリの PR やコミットログを参考にして、もし流れが分かるならそれもヒントとして skill に書こうか

(The source repository is private, so it is not named here or in the skill — the numbers quoted are kept anonymous for the same reason.)

## What changed

**`skills/ever-better-drain/SKILL.md`**

`## Before the loop: is this repository typed yet?` becomes `## Before the loop`, with three questions instead of one:

- typed yet — unchanged
- **is the linter looking at the whole repository** — three things pin the scope independently (`ignores`, the path argument in the lint script, a wrapper that calls something else), a glob without a leading `**/` matches the root only, and the way to find out is to plant a violation per top-level directory rather than to read the config
- **is part of the backlog dead code** — take `knip`'s orphans first; compute reachability by resolving import specifiers, never by grepping the basename

`### 1. Pick the rule` becomes `### 1. Pick the rule — and the order to take them in`, and gains a ranked list:

1. what `--fix` can take, including `--report-unused-disable-directives`
2. counts that are a config bug — `eslint --print-config`, not the config source
3. the singletons, batched into one PR
4. the small rules, one per PR
5. the big rules split by directory, in blast-radius order
6. the refactor rules last

It also states why small-first works in this tool specifically: suppressions are per file, so every file taken to zero is locked by `prune` on the way past.

work in ever-better