### PR TITLE
fix: four things writing the article surfaced

### DIFF
--- a/.github/ISSUE_TEMPLATE/results.yml
+++ b/.github/ISSUE_TEMPLATE/results.yml
@@ -1,0 +1,75 @@
+name: "Report a run"
+description: "What ever-better froze on your repository, and what came out of it. Numbers only — no code needs to leave your machine."
+title: "results: <language> / <rough age> / <N> frozen"
+labels: ["results"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        There are two data points in the world right now — a 13-year-old JavaScript CLI and a
+        current TypeScript app — and both are mine. That is not enough to say anything general
+        about how many real bugs a frozen backlog is hiding.
+
+        Every field is optional. A row with three numbers in it is still worth more than nothing.
+
+        **Nothing here asks for source.** If a number would identify a private repository, round it
+        or leave it out.
+
+  - type: input
+    id: shape
+    attributes:
+      label: What kind of repository
+      description: "Language, roughly how old, roughly how big. No name needed."
+      placeholder: "TypeScript, ~3 years, 900 files, browser + Node"
+
+  - type: input
+    id: frozen
+    attributes:
+      label: How many violations froze
+      description: "The number `ever-better freeze` printed. If you widened the rule set later, say which number this is."
+      placeholder: "4,942 — first freeze, before sonarjs was added"
+
+  - type: input
+    id: now
+    attributes:
+      label: Where it stands now
+      description: "And how long it took to get there — days, and pull requests if you know."
+      placeholder: "741 after 5 days / 207 PRs"
+
+  - type: textarea
+    id: bugs
+    attributes:
+      label: Real bugs, if any
+      description: |
+        The part nobody can measure without you: how many of those violations turned out to be
+        actual defects, and which rule found each one. Link the fix if it is public.
+      placeholder: |
+        2  no-undef                      — two ReferenceErrors in error paths, never reachable in normal use
+        6  security/detect-object-injection — a lookup answering out of the prototype chain
+        1  sonarjs/super-linear-regex    — froze the tab on a long input
+        0  id-length                     — noise here, all of it
+
+  - type: textarea
+    id: wrong
+    attributes:
+      label: Where the tool was wrong
+      description: |
+        Rules that were simply incorrect for your repository, a diagnosis that missed something, a
+        step that stalled. This is as useful as the successes — more, probably.
+      placeholder: "detect-object-injection flagged 400 sites and every one was a literal key."
+
+  - type: dropdown
+    id: entry
+    attributes:
+      label: How you ran it
+      options:
+        - "Claude Code plugin"
+        - "Handed an agent the README URL"
+        - "CLI only"
+        - "Something else"
+
+  - type: markdown
+    attributes:
+      value: |
+        Results get collected in [`docs/RESULTS.md`](../blob/main/docs/RESULTS.md). Say so here if
+        you would rather your row stayed anonymous.

--- a/README.md
+++ b/README.md
@@ -329,6 +329,19 @@ a new test, a deleted orphan — done, not asked about. Only a refactor needing 
 becomes a GitHub issue, and that issue says what the options are and which one the agent would
 pick.
 
+## Results, and what they do not yet show
+
+[`docs/RESULTS.md`](docs/RESULTS.md) collects what people froze and how much of it turned out to be
+defects rather than style. It has **two rows, and both are mine** — a 13-year-old JavaScript CLI and
+a current TypeScript app — which is enough to notice a pattern and nowhere near enough to claim one.
+
+Both, so far, produced the same bug: a lookup keyed on a string from outside, answered by the
+prototype chain, which no type system objects to.
+
+If you run this on anything, please add a row —
+[report a run](https://github.com/isamu/ever-better/issues/new?template=results.yml). Numbers only,
+no source. A run that found **zero** real bugs is the most useful row that table could get.
+
 ## Design
 
 The CLI does what is deterministic — detect, install, count, render, gate. The skills do what

--- a/docs/RESULTS.md
+++ b/docs/RESULTS.md
@@ -1,0 +1,39 @@
+# Results
+
+What ever-better froze on real repositories, and how much of it turned out to be defects rather
+than style.
+
+**Two rows are not a finding.** Both below are mine, which means the only thing they establish is
+that the question is worth asking. Add yours with the
+[report-a-run template](https://github.com/isamu/ever-better/issues/new?template=results.yml) —
+numbers only, no source.
+
+## Runs
+
+| Repository | Frozen | Now | Elapsed | Real bugs | Entry |
+| --- | ---: | ---: | --- | ---: | --- |
+| [pm2](https://github.com/Unitech/pm2) — JavaScript, 13 years, ★43k | 4,942 | 3,278 + 1,037 warn | 2 days / 102 commits | 13 | plugin |
+| private — TypeScript, current, ~900 files | 3,689 | 741 | 5 days / 207 PRs | 8+ | plugin |
+
+The second row's "frozen" is measured rather than recorded: `no-explicit-any` was `off` in most
+directories on day one, so the freeze at the time read 79 for that rule. 3,689 is the same tree
+with every tier switched on — the honest starting point, and the reason a raw before/after on that
+repository understates the work by a factor of five.
+
+## What the bugs were
+
+The pattern that repeats across both, and the reason this file exists:
+
+| Rule | Bugs | What it actually was |
+| --- | ---: | --- |
+| `security/detect-object-injection` | 8 | A lookup keyed on a string from outside, answered by the prototype chain. `table["constructor"]` returns a function nobody put there, the `if (!found)` guard never fires, and the not-found branch is dead. **No type objects** — `Record<string, T>` claims that key holds a `T`. |
+| `no-undef` | 2 | Two `ReferenceError`s in pm2, both on paths that only run after something else has already failed. Thirteen years unreported, because the user sees a stack trace instead of the message the author wrote. [Fixed upstream](https://github.com/Unitech/pm2/pull/6143). |
+| `sonarjs/super-linear-regex` | ~112 fixed | Quadratic and cubic patterns. Fine on every input anyone tried; freezes on the one nobody did. Worth noting: the rule was wrong in both directions — it flagged patterns that did not blow up, and missed a cubic one. Each was confirmed by measuring runtime against input length before being fixed. |
+
+## What would make this file useful
+
+- **More languages.** Both rows are JS/TS. A rule set's bug yield is not portable across ecosystems.
+- **A repository nobody's author is reporting on.** Both rows are self-reported by the person who
+  ran the tool, which is the weakest possible evidence.
+- **Negative results.** A run that froze 3,000 violations and found zero defects is the most
+  valuable row this table could get, and the least likely to be volunteered.

--- a/formatters/rule-counts.js
+++ b/formatters/rule-counts.js
@@ -17,6 +17,13 @@
  */
 const ERROR_SEVERITY = 2;
 
+/**
+ * A message with no `ruleId` is a parse or config error, which `--suppress-all` cannot record — so
+ * it fails the build, and the count alone says nothing about where. A few examples are enough to
+ * act on, and the cap keeps this output constant-size the way the counts already are.
+ */
+const UNATTRIBUTED_SAMPLE_LIMIT = 3;
+
 const tally = (target, ruleId) => {
   const key = ruleId ?? "(parse error)";
   target[key] = (target[key] ?? 0) + 1;
@@ -26,15 +33,20 @@ export default function ruleCounts(results) {
   const errors = {};
   const warnings = {};
   const suppressed = {};
+  const unattributed = [];
 
   for (const result of results) {
     for (const message of result.messages) {
       tally(message.severity === ERROR_SEVERITY ? errors : warnings, message.ruleId);
+      const unnamed = message.ruleId === null || message.ruleId === undefined;
+      if (unnamed && message.severity === ERROR_SEVERITY && unattributed.length < UNATTRIBUTED_SAMPLE_LIMIT) {
+        unattributed.push({ file: result.filePath, line: message.line ?? 0, message: message.message });
+      }
     }
     for (const message of result.suppressedMessages ?? []) {
       tally(suppressed, message.ruleId);
     }
   }
 
-  return JSON.stringify({ errors, warnings, suppressed, files: results.length });
+  return JSON.stringify({ errors, warnings, suppressed, unattributed, files: results.length });
 }

--- a/skills/ever-better-drain/SKILL.md
+++ b/skills/ever-better-drain/SKILL.md
@@ -84,6 +84,19 @@ usually surfaces it:
 | `consistent-type-assertions` | an `as` asserting something that was never true |
 | `max-depth`, `complexity` | a branch nobody has read in years, often unreachable |
 | `no-unused-vars` | the leftover half of an abandoned refactor |
+| `security/detect-object-injection` | a lookup keyed on a string from outside, answered by the prototype chain |
+| `sonarjs/slow-regex`, `sonarjs/super-linear-regex` | a pattern that is fine on every input anyone tried, and hangs on the one nobody did |
+
+**The prototype lookup is worth hunting by hand, because it is the one bug the type system
+endorses.** `Record<string, Thing>` says every key holds a `Thing`, so `table[key]` typechecks as a
+`Thing` — while at runtime `key = "constructor"` returns a function nobody put there, `if (!found)`
+does not fire, and the not-found branch is dead code. It has now turned up in an unrelated pair of
+repositories: twice in a 13-year-old JavaScript CLI, six times in a current TypeScript UI. It is a
+property of the language, not of old code.
+
+Grep for the shape — any bracket access whose key is not a literal — and settle it once, one way,
+for the whole repository: `Object.create(null)`, `Object.hasOwn()`, or a `Map`. Which one is the
+owner's call; picking a different one per site is how it comes back.
 
 **When a fix changes behaviour, that is a bug, and a bug gets a test.** Say so in the commit
 message; do not fold it silently into a lint cleanup.
@@ -92,15 +105,25 @@ message; do not fold it silently into a lint cleanup.
 site.** Types flow downhill: one annotation at the origin deletes the finding everywhere below it,
 while twenty edits at the sites delete twenty findings and leave the cause. In order:
 
-1. **The origin** — `JSON.parse`, `await response.json()`, a library that returns `any`, a config
-   read off disk. One type here usually collapses a whole cluster at once.
-2. **The container before the elements.** If the members of an array or a record are `any`, go and
+1. **First check whether the type already exists.** On a real codebase this is the largest category
+   by a distance: the ORM already types the row it returns, the SDK already types its events, the
+   component library already types its props — and someone wrote `: any` over the top of it. There
+   is nothing to write. Deleting the annotation restores the type the compiler knew all along. Do
+   this whole group before writing a single new type, because it is both the biggest and the
+   cheapest, and it shrinks the count you are reasoning about.
+2. **The origin** — `JSON.parse`, `await response.json()`, a library that genuinely returns `any`, a
+   config read off disk. One type here usually collapses a whole cluster at once. Follow the flow
+   upstream rather than counting: a single `any` on one private method has been measured taking out
+   the types of an entire route, so one fix upstream beats twenty at the sites.
+3. **The container before the elements.** If the members of an array or a record are `any`, go and
    find the type of the array and give it one — `Item[]`, not `any[]` fixed element by element. The
    element annotations then have nothing left to say and come out with it.
-3. **`catch (e: any)`** is an access problem wearing a type: the body wants `e.message`. `unknown`
+4. **`catch (e: any)`** is an access problem wearing a type: the body wants `e.message`. `unknown`
    plus one `errorMessage(error: unknown): string` helper settles every site at once, and the helper
-   is pure, so it is a single test rather than fifty edits.
-4. **`as any` last.** It is not a type, it is an assertion that the checker was wrong, so removing
+   is pure, so it is a single test rather than fifty edits. Expect this to be the single largest
+   identical group in the repository — 169 sites in one measured case, all collapsing into one
+   four-line function.
+5. **`as any` last.** It is not a type, it is an assertion that the checker was wrong, so removing
    one costs evidence about what the value really is. Some turn out to be right — those are the ones
    that deserve a named type rather than a deletion.
 
@@ -112,6 +135,23 @@ is validation, not annotation), and anything on an exported signature. Those are
 how many files import it, so "a dozen files read this type" is a number. It is a flag because it
 reads every source file, and it changes no ordering: a widely imported file is only expensive for
 the rules that move types, and that judgement is yours.
+
+**When `no-explicit-any` is measured in the thousands, it is not one PR.** A rule that big needs a
+ratchet of its own inside the ratchet, because the file-level suppressions do not stop the count
+climbing in a directory nobody has reached yet:
+
+- **Promote by directory.** Hold the rule at `off` where nothing has been done, `warn` where work is
+  in progress, and `error` on every directory that is finished. A finished directory cannot regress,
+  and the boundary moves one directory at a time instead of the whole repo moving at once.
+- **Slice an identical group.** 167 sites of the same shape is not reviewable as one diff; five PRs
+  of roughly fifteen to twenty are. Same rule, same shape, one PR per slice.
+- **Inventory the remainder rather than counting it.** Once the cheap groups are gone, write down
+  what each of the survivors actually needs — delete only, import a library type, write a new type,
+  needs a design change — and the number stops being a wall. In one measured case most of the
+  remaining hundred turned out to be delete-only, which is invisible while it is still a count.
+- **Prove the behaviour did not move.** A type-only PR must produce identical output; `emit-diff`
+  (step 6b) is the check. Changing behaviour while believing you were only fixing types is the
+  failure mode this whole tier has.
 
 **A rule ESLint can fix is not this work.** `no-var`, `prefer-const`, `no-else-return`,
 `sonarjs/no-collapsible-if` and Prettier are all fixable: take the whole rule in one command —

--- a/skills/ever-better-drain/SKILL.md
+++ b/skills/ever-better-drain/SKILL.md
@@ -143,8 +143,11 @@ climbing in a directory nobody has reached yet:
 - **Promote by directory.** Hold the rule at `off` where nothing has been done, `warn` where work is
   in progress, and `error` on every directory that is finished. A finished directory cannot regress,
   and the boundary moves one directory at a time instead of the whole repo moving at once.
-- **Slice an identical group.** 167 sites of the same shape is not reviewable as one diff; five PRs
-  of roughly fifteen to twenty are. Same rule, same shape, one PR per slice.
+- **Slice an identical group.** 167 sites of the same shape went in as five PRs of roughly fifteen
+  to twenty. The constraint is not that a reviewer refuses the big diff — the reviewer is an agent
+  and will read all 167 without complaint. It is that recall falls as the diff grows, and every
+  hunk in a group like this looks plausible, so the one site whose shape is genuinely different is
+  exactly what a long review waves through. Slice for the accuracy of the review, not its capacity.
 - **Inventory the remainder rather than counting it.** Once the cheap groups are gone, write down
   what each of the survivors actually needs — delete only, import a library type, write a new type,
   needs a design change — and the number stops being a wall. In one measured case most of the

--- a/skills/ever-better-drain/SKILL.md
+++ b/skills/ever-better-drain/SKILL.md
@@ -136,9 +136,18 @@ how many files import it, so "a dozen files read this type" is a number. It is a
 reads every source file, and it changes no ordering: a widely imported file is only expensive for
 the rules that move types, and that judgement is yours.
 
-**When `no-explicit-any` is measured in the thousands, it is not one PR.** A rule that big needs a
-ratchet of its own inside the ratchet, because the file-level suppressions do not stop the count
-climbing in a directory nobody has reached yet:
+**When `no-explicit-any` is measured in the thousands, it is not the rule to start with.** Finding
+the ten violations that matter inside 1,413 is not a thing anyone does, and every other rule's
+findings sit underneath it. Leaving it `off` at the beginning is sequencing, not surrender: clear
+the mechanical tiers first — formatting, unused bindings, `var`, the `--fix`-able rules — and come
+back to it once the repository is in shape. Taken last it is where the largest single reduction
+comes from; taken first it is where the effort stops on day one.
+
+What `off` must not become is the end state. A rule switched off is a place nobody is checking, and
+`any` is not "the type is unknown" — it is a decision about the type that was never written down.
+
+**When you do come back to it, that rule needs a ratchet of its own inside the ratchet,** because
+the file-level suppressions do not stop the count climbing in a directory nobody has reached yet:
 
 - **Promote by directory.** Hold the rule at `off` where nothing has been done, `warn` where work is
   in progress, and `error` on every directory that is finished. A finished directory cannot regress,

--- a/skills/ever-better-migrate/SKILL.md
+++ b/skills/ever-better-migrate/SKILL.md
@@ -83,15 +83,11 @@ the code dereferences it, that is a crash nobody had reproduced. Fix it, write t
 in the commit message rather than folding it into "migrate".
 
 If the count is large enough to be its own project, **loosen the tsconfig rather than stalling** —
-`strict: false` compiles, and:
-
-```bash
-npx ever-better strictness
-```
-
-prices each flag separately, so they can be switched on one at a time later with the cost known in
-advance. A repo that compiles loosely today and tightens on a schedule beats one that has been
-mid-migration for a month.
+`strict: false` compiles, and `bootstrap` has already priced each strictness flag separately, by
+enabling it in a temporary config that extends yours and counting the errors. Its report names the
+flags it enabled at zero cost and the ones it left off with what each would cost, so they can be
+switched on one at a time later with the price known in advance. A repo that compiles loosely today
+and tightens on a schedule beats one that has been mid-migration for a month.
 
 ### 5. Never reach for a cast
 

--- a/src/bootstrapPlan.ts
+++ b/src/bootstrapPlan.ts
@@ -40,7 +40,7 @@ const missingPackages = (options: BootstrapPlanOptions): string[] => {
   const have = installed(options.packageJson);
   const { framework, language, tooling } = options.diagnosis;
   const typed = language !== "javascript";
-  const wanted = [...eslintPackagesFor(framework, options.diagnosis.runtime), "prettier"];
+  const wanted = [...eslintPackagesFor(framework), "prettier"];
   if (typed) {
     wanted.push("typescript", "@types/node");
     // `tsc` cannot read an SFC at all, so a Vue repo typechecking with it silently skips every

--- a/src/commands/freeze.ts
+++ b/src/commands/freeze.ts
@@ -1,4 +1,7 @@
+import { relative } from "node:path";
+
 import { runRuleCounts, suppressAll, totalOf } from "../eslintRunner.ts";
+import type { RuleCounts } from "../eslintRunner.ts";
 import { writeQualityFile } from "../qualityFile.ts";
 import { applyRuleCounts, emptyState, readState, setCounter, WARNINGS_COUNTER, withPhase, writeState } from "../state.ts";
 import type { State } from "../types.ts";
@@ -7,6 +10,29 @@ export type FreezeOptions = {
   cwd: string;
   /** Allows a ceiling to move UP. Only correct when a rule was deliberately reconfigured. */
   force: boolean;
+};
+
+/**
+ * `--suppress-all` covers rule violations, so anything left is something ESLint could not attribute
+ * to a rule — almost always a parse error or a config-level complaint. "Fix the config" was the
+ * whole message, which sends the reader to the config they just generated rather than to the file
+ * that is actually failing. Naming the rules turns a mystery into a task.
+ *
+ * The commonest one on a repository older than ESLint 9 is an `eslint-env` block comment, which
+ * flat config rejects outright. Those are already dead — flat config never honoured them — so
+ * deleting them changes nothing and clears the error.
+ */
+const unsuppressedReport = (counts: RuleCounts, cwd: string): string[] => {
+  const total = totalOf(counts.errors);
+  if (total === 0) return [];
+  const byCount = Object.entries(counts.errors).sort(([, a], [, b]) => b - a);
+  const samples = (counts.unattributed ?? []).map(({ file, line, message }) => `  ${relative(cwd, file)}:${line}  ${message}`);
+  return [
+    `WARNING: ${total} error(s) could not be suppressed and will fail CI:`,
+    ...byCount.map(([rule, count]) => `  ${count}  ${rule}`),
+    ...(samples.length > 0 ? ["", "Where they are:", ...samples] : []),
+    "These are not rule violations the baseline can grandfather. Fix them before committing.",
+  ];
 };
 
 export const runFreeze = async (options: FreezeOptions): Promise<string> => {
@@ -34,13 +60,12 @@ export const runFreeze = async (options: FreezeOptions): Promise<string> => {
 
   const backlog = totalOf(counts.suppressed);
   const warnings = totalOf(counts.warnings);
-  const errors = totalOf(counts.errors);
   return [
     `Baseline pinned: ${backlog} violations across ${Object.keys(counts.suppressed).length} rules are now grandfathered.`,
     warnings > 0
       ? `${warnings} warnings stay visible — ESLint cannot suppress those, so their total is ratcheted instead.`
       : "New code is held to the full rule set from here.",
-    errors > 0 ? `WARNING: ${errors} errors could not be suppressed and will fail CI. Fix the config before committing.` : "",
+    ...unsuppressedReport(counts, options.cwd),
     "",
     "Commit eslint-suppressions.json, .ever-better/state.json and QUALITY.md.",
     "Next: pick the rule with the smallest count in QUALITY.md and drain it.",

--- a/src/detect/tooling.ts
+++ b/src/detect/tooling.ts
@@ -22,9 +22,22 @@ export const detectEslintSetup = (rootEntries: readonly string[]): EslintSetup =
   return "none";
 };
 
+/**
+ * Runners that are a dependency and nothing else — no config to generate, but their presence is the
+ * whole point: `bootstrap` installs vitest when it sees "none", so a repo that already tests with
+ * mocha gets a second runner added to it. Measured on debug-js/debug, which carries mocha in
+ * devDependencies and was reported as having no runner at all.
+ *
+ * A test script alone is still not evidence. `"test": "echo nope"` names no runner, and guessing
+ * from it would put this back to claiming tools that are not there.
+ */
+const DEPENDENCY_ONLY_RUNNERS = ["mocha", "ava", "tap", "jasmine"] as const;
+
 export const detectTestRunner = (packageJson: PackageJson | null): TestRunner => {
   if (hasDependency(packageJson, "vitest")) return "vitest";
   if (hasDependency(packageJson, "jest")) return "jest";
+  const named = DEPENDENCY_ONLY_RUNNERS.find((runner) => hasDependency(packageJson, runner));
+  if (named) return named;
   const testScript = packageJson?.scripts?.["test"] ?? "";
   if (testScript.includes("node --test") || testScript.includes("node:test")) return "node:test";
   return "none";

--- a/src/eslintRunner.ts
+++ b/src/eslintRunner.ts
@@ -13,6 +13,12 @@ export type RuleCounts = {
   warnings: Record<string, number>;
   /** Violations held by `eslint-suppressions.json` — the backlog that has to fall. */
   suppressed: Record<string, number>;
+  /**
+   * A bounded sample of the errors ESLint could not attribute to a rule — parse and config
+   * failures. `--suppress-all` cannot record these, so they fail the build with no rule name to
+   * look up, and a count on its own does not say which file to open.
+   */
+  unattributed?: { file: string; line: number; message: string }[];
   files: number;
 };
 

--- a/src/generate/eslintConfig.ts
+++ b/src/generate/eslintConfig.ts
@@ -40,16 +40,19 @@ const BASE_PACKAGES = [
  */
 
 /**
- * The security plugin only where its rules can apply: everything it looks for — child processes,
- * non-literal fs paths, unsafe regexes — is Node-side. On a browser-only bundle it is noise.
+ * The security plugin everywhere, because two of its rules are not Node-side and the browser is
+ * where both were measured. `detect-object-injection` is the only rule in this whole config that
+ * sees `obj[key]` answering out of the prototype chain — a lookup keyed on `"constructor"` returns
+ * a function, the `if (!found)` guard never fires, and no type says otherwise, since a
+ * `Record<string, T>` claims that key holds a `T`. Six of those were in a browser UI. And a
+ * super-linear regex freezes the tab, not the server.
+ *
+ * What is genuinely Node-side is turned off below rather than dropping the plugin: a rule that
+ * cannot fire costs nothing, and a rule that is missing costs six bugs.
  */
-const securityPackages = (runtime: Runtime): string[] => (runtime === "browser" ? [] : ["eslint-plugin-security"]);
+const securityPackages = (): string[] => ["eslint-plugin-security"];
 
-export const eslintPackagesFor = (framework: Framework, runtime: Runtime = "node"): string[] => [
-  ...BASE_PACKAGES,
-  ...securityPackages(runtime),
-  ...frameworkParts(framework, true).packages,
-];
+export const eslintPackagesFor = (framework: Framework): string[] => [...BASE_PACKAGES, ...securityPackages(), ...frameworkParts(framework, true).packages];
 
 /**
  * The config is written as ESM either way. In a package without `"type": "module"` — which is most
@@ -262,16 +265,41 @@ const testBlock = (options: EslintConfigOptions): string[] => [
  */
 const disableDirectiveBlock = (): string[] => ["  {", "    linterOptions: {", '      reportUnusedDisableDirectives: "error",', "    },", "  },"];
 
-const securityImport = (runtime: Runtime): string[] => (runtime === "browser" ? [] : ['import security from "eslint-plugin-security";']);
+const securityImport = (): string[] => ['import security from "eslint-plugin-security";'];
 
-const securityBlock = (runtime: Runtime): string[] => (runtime === "browser" ? [] : ["  security.configs.recommended,"]);
+/** Nothing in a bundle spawns a process, reads a path off disk or allocates a Buffer. */
+const NODE_ONLY_SECURITY_RULES = [
+  "security/detect-buffer-noassert",
+  "security/detect-child-process",
+  "security/detect-new-buffer",
+  "security/detect-no-csrf-before-method-override",
+  "security/detect-non-literal-fs-filename",
+  "security/detect-non-literal-require",
+  "security/detect-pseudoRandomBytes",
+];
+
+const securityBlock = (runtime: Runtime): string[] => {
+  const preset = "  security.configs.recommended,";
+  if (runtime !== "browser") return [preset];
+  return [
+    preset,
+    "  {",
+    "    // Kept on a browser bundle: detect-object-injection, which is the only rule here that",
+    "    // sees a lookup answering out of the prototype chain, and the regex rules, because a",
+    "    // super-linear pattern freezes the tab.",
+    "    rules: {",
+    ...NODE_ONLY_SECURITY_RULES.map((rule) => `      "${rule}": "off",`),
+    "    },",
+    "  },",
+  ];
+};
 
 export const renderEslintConfig = (options: EslintConfigOptions): string => {
   const framework = frameworkParts(options.framework, options.typed);
   return [
     ...HEADER,
     ...BASE_IMPORTS,
-    ...securityImport(options.runtime),
+    ...securityImport(),
     ...framework.imports,
     "",
     "export default tseslint.config(",

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export type Runtime = "browser" | "node" | "both";
 
 export type EslintSetup = "flat" | "legacy" | "none";
 
-export type TestRunner = "vitest" | "jest" | "node:test" | "none";
+export type TestRunner = "vitest" | "jest" | "mocha" | "ava" | "tap" | "jasmine" | "node:test" | "none";
 
 /** `mixed` means TypeScript is configured but a meaningful share of sources are still `.js`. */
 export type LanguageMode = "typescript" | "mixed" | "javascript";

--- a/test/test_detect.ts
+++ b/test/test_detect.ts
@@ -87,6 +87,17 @@ describe("detectTestRunner", () => {
   it("reports none rather than guessing", () => {
     assert.equal(detectTestRunner({ scripts: { test: "echo nope" } }), "none");
   });
+
+  it("names the runners that are only ever a dependency", () => {
+    // Reporting mocha as "none" is not a cosmetic mislabel: bootstrap installs vitest on "none",
+    // which puts a second runner into a repo that already tests. Measured on debug-js/debug.
+    assert.equal(detectTestRunner({ devDependencies: { mocha: "^11" } }), "mocha");
+    assert.equal(detectTestRunner({ devDependencies: { ava: "^6" } }), "ava");
+  });
+
+  it("prefers the runner a config would be generated for", () => {
+    assert.equal(detectTestRunner({ devDependencies: { mocha: "^11", vitest: "^4" } }), "vitest");
+  });
 });
 
 describe("detectTooling", () => {

--- a/test/test_render.ts
+++ b/test/test_render.ts
@@ -277,10 +277,19 @@ describe("renderEslintConfig — readability and security tiers", () => {
     assert.match(renderEslintConfig(opts), /security\.configs\.recommended/);
   });
 
-  it("leaves the security tier out of a browser-only bundle", () => {
-    // Everything it looks for — child processes, non-literal fs paths — is Node-side.
+  it("keeps the security tier on a browser bundle, minus the rules that cannot fire", () => {
+    // detect-object-injection is the only rule in the whole config that sees a lookup answering
+    // out of the prototype chain, and that bug is not Node-side — six of them were in browser UI.
     const browser = renderEslintConfig({ ...opts, runtime: "browser" });
-    assert.ok(!browser.includes("eslint-plugin-security"));
+    assert.match(browser, /security\.configs\.recommended/);
+    assert.ok(!browser.includes('"security/detect-object-injection": "off"'));
+    assert.ok(!browser.includes('"security/detect-unsafe-regex": "off"'));
+    assert.match(browser, /"security\/detect-child-process": "off"/);
+    assert.match(browser, /"security\/detect-non-literal-fs-filename": "off"/);
+  });
+
+  it("leaves the Node-only opt-outs off a Node config", () => {
+    assert.ok(!renderEslintConfig(opts).includes('"security/detect-child-process": "off"'));
   });
 
   it("states no-var and prefer-const itself, because the preset scopes them to .ts", () => {


### PR DESCRIPTION
## Summary

Four fixes, all found by using the tool rather than reading it — three while writing the article about it, one by running the whole loop on a fresh clone of [debug-js/debug](https://github.com/debug-js/debug).

| | What was wrong | Cost |
|---|---|---|
| **security tier** | `security.configs.recommended` was dropped entirely for `runtime: "browser"` | `detect-object-injection` is the only rule in the config that sees a prototype-chain lookup, and 6 of those were in browser UI |
| **`strictness`** | The migrate skill told the agent to run `npx ever-better strictness` | The command does not exist. `Unknown command`, mid-migration |
| **mocha** | `detectTestRunner` knew only vitest / jest / node:test | `bootstrap` installs vitest on `"none"` — a second runner into a repo that already tests |
| **freeze message** | `WARNING: N errors could not be suppressed. Fix the config before committing.` | Named neither the rule nor the file. These have no rule id by definition |

## Items to Confirm / Review

1. **`detect-object-injection` is noisy** — it flags every non-literal bracket access, so browser repos will freeze a visibly larger number. Deliberate: the ceiling absorbs it and new code is held. **Confirm that trade.**
2. **Denylist rather than allowlist** for the security rules. A new upstream rule now reaches browser repos by default and has to be turned off if Node-only. The alternative fails the other way, which is why this PR exists.
3. **`ava` / `tap` / `jasmine` are unverified** — added on the same one-line dependency check as mocha, which *was* measured. If you would rather only ship what was tested, drop them.
4. **The unattributed sample is capped at 3** in `formatters/rule-counts.js`, to keep that output constant-size as its header comment requires. Three was a guess.

## Evidence

**Prototype lookup**, the reason for fix 1:

| | prototype lookup | super-linear regex |
|---|---|---|
| 13-year-old JS CLI (pm2), Node | 2 | — |
| current TS UI, browser | 6 | 23 |

The browser column is the one this config was not checking. `Record<string, T>` claims the key holds a `T`, so no type objects either.

**The debug-js/debug run**, which produced fixes 3 and 4:

```
diagnose   9 gaps → 8 after the mocha fix (vitest no longer in the install plan)
bootstrap  9 deps + eslint.config.mjs + 6 workflows + dependabot
freeze     72 violations across 10 rules grandfathered
check      new file with 3 violations → exit 1, existing 72 still silent
```

Before / after on the freeze message:

```
- WARNING: 5 errors could not be suppressed and will fail CI. Fix the config before committing.

+ WARNING: 5 error(s) could not be suppressed and will fail CI:
+   5  (parse error)
+
+ Where they are:
+   src/browser.js:1  /* eslint-env */ comments are no longer supported.
+   src/browser.js:134  Unused eslint-disable directive (no problems were reported from 'no-return-assign').
+   src/common.js:205  Unused eslint-disable directive (no problems were reported from 'no-negated-condition').
+ These are not rule violations the baseline can grandfather. Fix them before committing.
```

## Also in this PR

- `skills/ever-better-drain/SKILL.md` — the two bug families in the "what the fix uncovers" table, a note that the prototype lookup must be hunted by hand **because the type system endorses it**, and the operational half of a `no-explicit-any` backlog in the thousands: leaving it `off` at the start is sequencing rather than surrender; the largest group is `: any` written over types the library **already publishes**; directory-level promotion `off → warn → error`; slicing an identical group for review *accuracy*, not reviewer capacity.
- `docs/RESULTS.md` + a report-a-run issue template — the bug-yield claim rests on two repositories and both are mine. Says so plainly, and asks for rows.

## Gates

`yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test` — green, 270 tests. `claude plugin validate .` passes on both the working tree and a fresh clone of `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal-marketing