### PR TITLE
docs: for a big refactor, keep the old body and diff against it

### DIFF
--- a/skills/ever-better-drain/SKILL.md
+++ b/skills/ever-better-drain/SKILL.md
@@ -72,6 +72,39 @@ For a change that is *supposed* to alter behaviour — a bug the rule uncovered 
 the other way: write it, watch it fail, then fix. And for a refactor that is purely types, `emit-diff`
 in step 6b proves more than either (see below).
 
+**When the function is too big to characterise with a handful of tests, keep the old one and diff
+against it.** A few hand-written cases cover the branches you thought of, which on a 300-line
+function is not the set that matters. The old implementation already knows every answer, so make it
+the oracle rather than trying to restate it:
+
+```ts
+// The old body, renamed and otherwise untouched. Delete it in a later PR, not this one.
+const buildReportLegacy = (input: Input): Report => { /* … as it was … */ };
+
+const buildReport = (input: Input): Report => { /* … the split-up version … */ };
+
+// The whole proof: same input, same output, over inputs you did not choose by hand.
+for (const input of recordedInputs) {
+  assert.deepStrictEqual(buildReport(input), buildReportLegacy(input));
+}
+```
+
+Two things make or break this:
+
+- **The inputs must not come from you.** Cases you invent test the branches you already understand.
+  Capture real ones — log the arguments in production or in a test run and replay them, walk a
+  fixture directory, or generate them. The branch that breaks is the one nobody wrote down.
+- **The old body is copied, not called through.** If the new code delegates to the old code for the
+  hard part, the diff passes and proves nothing.
+
+Where outputs are not comparable with `deepStrictEqual` — they contain a timestamp, an id, a `Map`
+in insertion order — normalise both sides through the same function rather than loosening the
+assertion. An assertion that ignores a field stops covering it.
+
+**Say in the PR body how many inputs it ran against, and where they came from.** "Behaviour is
+unchanged" is a claim; "identical output over the 1,840 recorded calls in `fixtures/`" is a
+measurement, and the reviewer can tell which one they are reading.
+
 ### 4. Fix them — and notice what the fix reveals
 
 This is the part that is not mechanical. A lint rule is a proxy for a real problem, and the fix


### PR DESCRIPTION
## Summary

The drain skill says a refactor's test must go first, against today's code. That holds for a seam you can characterise in a few cases. It does not hold for the 300-line function the `cognitive-complexity` tier eventually reaches — **a handful of hand-written cases covers the branches you already thought of, and the one that breaks is the one nobody wrote down.**

Adds the technique that does work there: the old implementation already knows every answer, so make it the oracle.

```ts
const buildReportLegacy = (input: Input): Report => { /* … as it was … */ };
const buildReport       = (input: Input): Report => { /* … the split-up version … */ };

for (const input of recordedInputs) {
  assert.deepStrictEqual(buildReport(input), buildReportLegacy(input));
}
```

## Items to Confirm / Review

1. **Two constraints do the work, and both are easy to violate** — the inputs must not be ones you invented (capture or generate them), and the old body must be *copied* rather than delegated to. If the new code calls the old code for the hard part, the diff passes and proves nothing. Confirm both are stated strongly enough.
2. **Normalise rather than loosen** — where outputs carry a timestamp or an id, both sides go through the same normaliser. An assertion that ignores a field stops covering it. This is a judgement call the skill now makes for the agent.
3. **Reporting** — the skill asks the PR body to say how many inputs it ran against and where they came from. "Behaviour is unchanged" is a claim; "identical over the 1,840 recorded calls in `fixtures/`" is a measurement.

## Why it belongs in this skill rather than a doc

`emit-diff` already covers the type-only case by comparing emitted JavaScript. This is the same principle — **prove it rather than assert it** — for the case where the output legitimately changes shape and `emit-diff` cannot help. The two together cover both ends of the refactor tier the drain phase ends on.

## Gates

`yarn format` / `yarn lint` / `yarn test` — green, 270 tests. Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal-marketing