### PR TITLE
ever-better@0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ever-better",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Diagnose a repository, install the quality tooling it is missing, and pin a baseline that can only get better.",
   "keywords": [
     "eslint",


### PR DESCRIPTION
## Summary

0.4.0 で公開したものに、**実際に使って見つかったバグ4件**の修正が入っています。記事（[Zenn](https://zenn.dev/singularity/articles/ever-better-pm2)）が `npx ever-better` を案内しているので、公開版を追いつかせるためのパッチリリースです。

## 何が直ったか

| | 症状 | 影響 |
|---|---|---|
| **security tier** | `runtime: "browser"` で `security.configs.recommended` を丸ごと外していた | `detect-object-injection` は生成される設定の中で**プロトタイプ経由の引きを見る唯一のルール**。そのバグ6件はブラウザの UI で見つかった |
| **`strictness`** | migrate スキルが `npx ever-better strictness` を実行させていた | そんなコマンドは無い。TypeScript 移行の途中で `Unknown command` |
| **mocha** | `detectTestRunner` が vitest / jest / node:test しか知らなかった | `"none"` を見ると bootstrap が **vitest を install する**。既にテストがあるリポジトリに2つ目のランナーが入る |
| **freeze の警告** | `N errors could not be suppressed. Fix the config before committing.` | ルール名もファイル名も出さない。抑制できないエラーは定義上ルール ID を持たないので、読む側に手がかりが無い |

## Items to Confirm / Review

1. **`detect-object-injection` はノイズが多い** — リテラルでない添字アクセスを全部拾うので、browser リポジトリの初回凍結数は目に見えて増えます。天井が吸収して新規だけ止める設計なので意図的ですが、**その取引でよいか確認をお願いします。**
2. **`ava` / `tap` / `jasmine` は未検証** — mocha と同じ1行の依存判定に乗せただけです。実測したものだけにしたい場合は外せます。
3. **バージョンは patch** — 公開 API の変更はありません。`TestRunner` の union と `RuleCounts.unattributed` が増えていますが、どちらも内部型です。

## 検証

- `yarn install` / `typecheck` / `lint` / `build` / `test`（270 pass）すべて green
- `claude plugin validate .` 通過
- [debug-js/debug](https://github.com/debug-js/debug) の新規クローンで diagnose → bootstrap → freeze → check を一周し、**新規違反で exit 1、既存72件は沈黙**を確認
- `npm pack --dry-run` で 0.4.1 のみを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal-marketing