### PR TITLE
feat: `ever-better report` — where the findings are, not just how many

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -76,6 +76,7 @@ npx ever-better bootstrap    # 導入して設定ファイルを生成
 npx ever-better freeze       # 今日の違反件数を天井として固定
 npx ever-better check        # CI のゲート: 件数が増えたら失敗
 npx ever-better next         # 何から潰すか、そしてそれが何を enforce するか
+npx ever-better report       # 指摘がどこにあるかを markdown で（CI のジョブサマリ向け）
 npx ever-better prune        # 直した分だけ天井を下げる
 ```
 
@@ -169,6 +170,21 @@ ever-better next --fan-in
 既定ではなくフラグなのは、import を解析するために**全ソースファイルを読む**からです（`migrate` と同じ重さで、編集の合間に叩くコマンドの重さではありません）。そして**並び順は一切変えません** — fan-in が高くつくのは*型*の修正であって、`max-depth` のように修正がそのファイル内で閉じるルールには何の関係もありません。数字は出す、どのルールで効くかの判断はスキル側 — この分担はツール全体と同じです。
 
 数えているのは直接の importer であって推移的な到達数ではなく、解決するのは相対指定だけです（path alias 経由でしか import されていないファイルは低く出ます）。
+
+### `report`
+
+```bash
+ever-better report
+ever-better report --json
+```
+
+バックログを**ルール × エリア**の表にした markdown を出します。`next` が「どの修正が一番多くを enforce するか」に答えるのに対し、こちらは「**このリポジトリの lint 負債はどういう形をしているのか**」に答えます。大きさではなく形です。
+
+stdout に出すのに加えて、`$GITHUB_STEP_SUMMARY` が設定されていればそこに**追記**します。これがワークフローを誰も編集せずに CI レポートになる仕組みです。生成される gate ワークフローは `check` の後に `if: always()` で実行します — **check が落ちた回こそ**バックログの形を知る価値が一番高いからです。
+
+warning に専用セクションがあるのが要点です。ESLint の suppressions が対象にするのは **error だけ**なので、warning は grandfather されず、放っておいても減りません。`state.json` が持っているのは warning 全体の合計1つだけでルール名は一切残らないため、**その内訳が存在する場所はここしかありません**。
+
+**これは gate ではありません。** 終了コードを変えませんし、サマリファイルに書けなくても失敗しません。ESLint が動かせない場合は `eslint-suppressions.json` だけにフォールバックし、その旨を出力に書きます —「warning が無い」と「誰も warning を見ていない」が同じ見た目になってはいけないからです。
 
 ### `prune`
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ npx ever-better bootstrap    # install it, generate the configs
 npx ever-better freeze       # pin today's violations as the ceiling
 npx ever-better check        # CI gate: fail if anything rose
 npx ever-better next         # what to drain first, and what each fix enforces
+npx ever-better report       # where the findings are, as markdown (for a CI job summary)
 npx ever-better prune        # after a fix: reclaim the ceiling you earned
 ```
 
@@ -220,6 +221,31 @@ which rules it applies to is judgment, and judgment is the skills' half of this 
 
 The count is direct importers, not transitive reach, and only relative specifiers resolve — a file
 imported solely through a path alias reads low.
+
+### `report`
+
+```bash
+ever-better report
+ever-better report --json
+```
+
+Markdown: the backlog as a **rule x area** table, so the shape of the debt is visible rather than
+just its size. Where `next` answers "which edit enforces the most", this answers "what does this
+repository's lint debt actually look like".
+
+It is written to stdout and **appended to `$GITHUB_STEP_SUMMARY`** when that is set, which is what
+makes it a CI report without anyone editing a workflow. The generated gate workflow runs it after
+`check` with `if: always()` — the run where `check` has just failed is the run where the backlog is
+worth most.
+
+Warnings get their own section, and that is the point of including them: ESLint's suppressions cover
+**errors only**, so a warning is never grandfathered and never drains. `state.json` keeps one grand
+total for the whole warning population and no rule ever appears in it; this is the only place that
+breakdown exists.
+
+**It is never a gate.** It cannot change an exit code, and it does not fail when the summary file
+cannot be written. If ESLint cannot run at all, it falls back to `eslint-suppressions.json` and says
+so in the output — "no warnings" and "nobody looked for warnings" must not render the same way.
 
 ### `prune`
 

--- a/docs/generated-config.md
+++ b/docs/generated-config.md
@@ -727,6 +727,12 @@ jobs:
 
       - name: ever-better check
         run: npx --yes ever-better check --no-write
+
+      # `always()`: the run where check has just failed is the run where knowing what the
+      # backlog looks like is worth most. A report is not a gate and never changes the result.
+      - name: ever-better report
+        if: always()
+        run: npx --yes ever-better report
 ```
 
 ### .github/workflows/codex-review.yml

--- a/formatters/rule-counts.js
+++ b/formatters/rule-counts.js
@@ -15,7 +15,32 @@
  * Plain JavaScript on purpose — it must load identically whether the CLI runs from `dist/` or
  * straight from TypeScript source, so it is never part of a build.
  */
+import path from "node:path";
+
 const ERROR_SEVERITY = 2;
+
+/** A file at the repository root belongs to no directory, and "" reads as missing data. */
+const ROOT_AREA = "(root)";
+
+/**
+ * The top-level directory a file sits in — `src`, `test`, `server`. Aggregated here for the same
+ * reason the counts are: an area breakdown built from `--format json` would carry every violation
+ * across the process boundary, while this stays bounded by areas x rules however bad the repo is.
+ *
+ * `context.cwd` is where ESLint ran, and `filePath` is absolute; both verified against ESLint 10
+ * rather than assumed.
+ */
+const areaOf = (filePath, cwd) => {
+  const relative = path.relative(cwd, filePath).split(path.sep).join("/");
+  const [first, ...rest] = relative.split("/");
+  return rest.length === 0 || first === undefined || first === "" ? ROOT_AREA : first;
+};
+
+const tallyArea = (target, area, ruleId) => {
+  const key = ruleId ?? "(parse error)";
+  const rules = (target[area] ??= {});
+  rules[key] = (rules[key] ?? 0) + 1;
+};
 
 /**
  * A message with no `ruleId` is a parse or config error, which `--suppress-all` cannot record — so
@@ -29,24 +54,30 @@ const tally = (target, ruleId) => {
   target[key] = (target[key] ?? 0) + 1;
 };
 
-export default function ruleCounts(results) {
+export default function ruleCounts(results, context) {
   const errors = {};
   const warnings = {};
   const suppressed = {};
   const unattributed = [];
+  const areas = { errors: {}, warnings: {}, suppressed: {} };
+  const cwd = context?.cwd ?? process.cwd();
 
   for (const result of results) {
+    const area = areaOf(result.filePath, cwd);
     for (const message of result.messages) {
-      tally(message.severity === ERROR_SEVERITY ? errors : warnings, message.ruleId);
+      const failing = message.severity === ERROR_SEVERITY;
+      tally(failing ? errors : warnings, message.ruleId);
+      tallyArea(failing ? areas.errors : areas.warnings, area, message.ruleId);
       const unnamed = message.ruleId === null || message.ruleId === undefined;
-      if (unnamed && message.severity === ERROR_SEVERITY && unattributed.length < UNATTRIBUTED_SAMPLE_LIMIT) {
+      if (unnamed && failing && unattributed.length < UNATTRIBUTED_SAMPLE_LIMIT) {
         unattributed.push({ file: result.filePath, line: message.line ?? 0, message: message.message });
       }
     }
     for (const message of result.suppressedMessages ?? []) {
       tally(suppressed, message.ruleId);
+      tallyArea(areas.suppressed, area, message.ruleId);
     }
   }
 
-  return JSON.stringify({ errors, warnings, suppressed, unattributed, files: results.length });
+  return JSON.stringify({ errors, warnings, suppressed, unattributed, areas, files: results.length });
 }

--- a/plans/feat-lint-report.md
+++ b/plans/feat-lint-report.md
@@ -1,0 +1,69 @@
+# `ever-better report` — where the findings are
+
+Issue: #49. Adapted from receptron/mulmoterminal#1647.
+
+## What is missing, traced rather than assumed
+
+`eslint .` names files. `ever-better status` gives per-rule totals. `ever-better next` ranks what to
+take first. None of them says **where the debt lives** — which areas of the repo carry which rules.
+
+Two populations exist here, and only one of them is mapped at all:
+
+| | recorded where | per rule | per file |
+| --- | --- | --- | --- |
+| suppressed (the backlog) | `eslint-suppressions.json`, `state.rules` | yes | yes |
+| **warnings** | one grand total in `state.counters` | **no** | **no** |
+| errors | nothing — they fail the build | no | no |
+
+The warning population is the one that matters most and is the one nobody can see. ESLint's
+suppressions cover **errors only**, so a warning is never grandfathered and never drains — it is
+permanently visible, ratcheted by ever-better's own counter, and today that counter is a single
+number with no breakdown behind it.
+
+## Where the area dimension comes from
+
+`formatters/rule-counts.js` already aggregates inside the formatter, for a stated reason: `--format
+json` grows with the number of violations and the first run on an untouched repo is when it is
+largest. The same argument applies to the area breakdown, so it is computed in the same place and
+what crosses the process boundary stays bounded by rules × areas.
+
+Verified against ESLint 10.8.1 rather than read from docs — a probe formatter reports
+`context` keys `["cwd", "rulesMeta"]`, an absolute `result.filePath`, and a real
+`suppressedMessages` array. So the area is `path.relative(context.cwd, filePath)`'s first segment,
+and a file at the root is `(root)`.
+
+**The formatter is on the critical path of `freeze`, `prune` and `check`, and had no test at all.**
+The change is additive — one new key — but it gets tests first, driven directly as the pure function
+it is.
+
+## Shape
+
+- `ever-better report` — markdown to stdout, and appended to `$GITHUB_STEP_SUMMARY` when that is set,
+  which is what makes it a CI report without any workflow edit by the user
+- the generated gate workflow gains a step that calls it, with `if: always()` so the report still
+  arrives when `check` has just failed — which is the run where it is most wanted
+- degrades to the suppressions file alone when ESLint cannot run, rather than failing
+
+## Files
+
+| File | What |
+| --- | --- |
+| `formatters/rule-counts.js` | add `areas`, bounded by rules × areas |
+| `src/eslintRunner.ts` | the `RuleCounts` type and its guard |
+| `src/lintReport.ts` | new, pure — totals, the rule × area matrix, the areas carrying the most |
+| `src/render/lintReport.ts` | new, pure — markdown |
+| `src/commands/report.ts` | new — run, build, render, append to the step summary |
+| `src/cli.ts` | the command |
+| `src/generate/gateWorkflow.ts` | the CI step |
+| `test/test_ruleCountsFormatter.ts` | new — the formatter had none |
+| `test/test_lintReport.ts` | new |
+| `test/test_render.ts` | the gate workflow step |
+
+## Decisions worth disagreeing with
+
+- **The report is not a gate.** It never changes an exit code. `check` is the gate and stays the only
+  one; a report that can fail a build is a second gate nobody asked for.
+- **Errors get totals, not a matrix.** After a freeze an unsuppressed error is new by definition, so
+  there are few of them and ESLint's own output already names the file and line.
+- **Row counts are capped and the cap is printed.** A table that silently shows its top ten reads as
+  the whole list.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import { isLogKind, LOG_KIND_LIST, runLog } from "./commands/log.ts";
 import { runMigrate } from "./commands/migrate.ts";
 import { runNext } from "./commands/next.ts";
 import { runPrune } from "./commands/prune.ts";
+import { runReport } from "./commands/report.ts";
 import { runStatus } from "./commands/status.ts";
 
 const USAGE = `ever-better — make a codebase that can only get better
@@ -23,6 +24,7 @@ const USAGE = `ever-better — make a codebase that can only get better
   check       fail if anything rose above its ceiling (for CI)
   status      print the current backlog
   next        what to drain first, and what each one enforces
+  report      where the findings are, by rule and area (markdown, for CI)
   emit-diff   prove a type-only refactor changed no behaviour
   catalog     list the helpers that already exist, so nobody writes a sixth
   migrate     JavaScript to TypeScript, the whole repo or one file at a time
@@ -88,6 +90,7 @@ const ALWAYS_OK: Record<string, (flags: Flags) => Promise<string>> = {
   prune: (flags) => runPrune({ cwd: flags.cwd }),
   status: (flags) => runStatus({ cwd: flags.cwd, json: flags.json }),
   next: (flags) => runNext({ cwd: flags.cwd, json: flags.json, fanIn: flags.fanIn }),
+  report: (flags) => runReport({ cwd: flags.cwd, json: flags.json }),
   catalog: (flags) => runCatalog({ cwd: flags.cwd }),
   migrate: (flags) => runMigrate({ cwd: flags.cwd, file: flags.file ?? null, all: flags.all }),
   "emit-diff": (flags) => runEmitDiff({ cwd: flags.cwd, against: flags.against }),

--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -1,0 +1,48 @@
+import { appendFile } from "node:fs/promises";
+import process from "node:process";
+import { runRuleCounts, type RuleCounts } from "../eslintRunner.ts";
+import { buildLintReport } from "../lintReport.ts";
+import { renderLintReport } from "../render/lintReport.ts";
+import { readSuppressions } from "../suppressionsFile.ts";
+
+export type ReportOptions = {
+  cwd: string;
+  json: boolean;
+};
+
+/**
+ * Actions sets this to a file every job may append markdown to. Writing there is what makes this a
+ * CI report without anyone editing a workflow, and outside Actions it is unset so a terminal run
+ * only ever prints.
+ */
+const STEP_SUMMARY = "GITHUB_STEP_SUMMARY";
+
+const appendToStepSummary = async (markdown: string): Promise<void> => {
+  const target = process.env[STEP_SUMMARY];
+  if (!target) return;
+  // A report is not a gate. Failing the job because the summary could not be written would make it
+  // one, and the markdown has already gone to stdout either way.
+  await appendFile(target, `${markdown}\n`, "utf8").catch(() => undefined);
+};
+
+/**
+ * A report is not a gate, so a repository that cannot lint still gets the half of the answer the
+ * ratchet file holds. The reason travels with it — "no warnings" and "nobody looked" have to read
+ * differently.
+ */
+const lint = async (cwd: string): Promise<{ counts: RuleCounts | null; failure: string | null }> => {
+  try {
+    return { counts: await runRuleCounts(cwd), failure: null };
+  } catch (error) {
+    return { counts: null, failure: error instanceof Error ? (error.message.split("\n")[0] ?? "unknown error") : String(error) };
+  }
+};
+
+export const runReport = async (options: ReportOptions): Promise<string> => {
+  const { counts, failure } = await lint(options.cwd);
+  const report = buildLintReport(counts, await readSuppressions(options.cwd), failure);
+  if (options.json) return JSON.stringify(report, null, 2);
+  const markdown = renderLintReport(report);
+  await appendToStepSummary(markdown);
+  return markdown;
+};

--- a/src/eslintRunner.ts
+++ b/src/eslintRunner.ts
@@ -19,7 +19,23 @@ export type RuleCounts = {
    * look up, and a count on its own does not say which file to open.
    */
   unattributed?: { file: string; line: number; message: string }[];
+  /**
+   * The same three buckets broken down by top-level directory, which is the only place the shape of
+   * the debt is visible: `state.rules` holds suppressed violations per rule, and warnings — which
+   * ESLint cannot suppress and which therefore never drain — reach the ledger as a single total.
+   *
+   * Optional because it is only what the current formatter emits; a command reading it degrades to
+   * the rule totals rather than failing.
+   */
+  areas?: AreaCounts;
   files: number;
+};
+
+/** Area to rule to count. Bounded by areas x rules, so it never grows with the violation count. */
+type AreaCounts = {
+  errors: Record<string, Record<string, number>>;
+  warnings: Record<string, Record<string, number>>;
+  suppressed: Record<string, Record<string, number>>;
 };
 
 export const totalOf = (counts: Readonly<Record<string, number>>): number => Object.values(counts).reduce((sum, count) => sum + count, 0);

--- a/src/generate/gateWorkflow.ts
+++ b/src/generate/gateWorkflow.ts
@@ -58,4 +58,10 @@ export const renderGateWorkflow = (packageManager: PackageManager, nodeVersion: 
     "      - name: ever-better check",
     "        run: npx --yes ever-better check --no-write",
     "",
+    "      # `always()`: the run where check has just failed is the run where knowing what the",
+    "      # backlog looks like is worth most. A report is not a gate and never changes the result.",
+    "      - name: ever-better report",
+    "        if: always()",
+    "        run: npx --yes ever-better report",
+    "",
   ].join("\n");

--- a/src/lintReport.ts
+++ b/src/lintReport.ts
@@ -1,0 +1,117 @@
+import type { RuleCounts } from "./eslintRunner.ts";
+import type { Suppression } from "./suppressionsFile.ts";
+
+/** A file at the repository root belongs to no directory, and "" reads as missing data. */
+const ROOT_AREA = "(root)";
+
+export type Matrix = Record<string, Record<string, number>>;
+
+type ReportRow = {
+  rule: string;
+  total: number;
+  /** Counts in the same order as the section's `areas`, so the renderer does no lookups. */
+  counts: number[];
+};
+
+export type ReportSection = {
+  title: string;
+  total: number;
+  areas: string[];
+  rows: ReportRow[];
+};
+
+export type LintReport = {
+  errorTotal: number;
+  warningTotal: number;
+  suppressedTotal: number;
+  files: number;
+  /** Rule totals only: after a freeze an unsuppressed error is new, and ESLint already named it. */
+  errors: { rule: string; count: number }[];
+  sections: ReportSection[];
+  /**
+   * Why no lint ran, when none did — the report then covers the ratchet file and nothing else, and
+   * a reader has to be able to tell "no warnings" from "nobody looked for warnings".
+   */
+  lintFailure: string | null;
+};
+
+export const areaOf = (file: string): string => {
+  const [first, ...rest] = file.split("/");
+  return rest.length === 0 || first === undefined || first === "" ? ROOT_AREA : first;
+};
+
+const totalOf = (counts: Readonly<Record<string, number>>): number => Object.values(counts).reduce((sum, count) => sum + count, 0);
+
+const matrixTotal = (matrix: Matrix): number => Object.values(matrix).reduce((sum, rules) => sum + totalOf(rules), 0);
+
+/** The ratchet file is per file per rule, which is the same information one directory up. */
+export const matrixFromSuppressions = (entries: readonly Suppression[]): Matrix => {
+  const matrix: Matrix = {};
+  entries.forEach((entry) => {
+    const area = (matrix[areaOf(entry.file)] ??= {});
+    area[entry.rule] = (area[entry.rule] ?? 0) + entry.count;
+  });
+  return matrix;
+};
+
+const rulesIn = (matrix: Matrix): string[] => [...new Set(Object.values(matrix).flatMap((rules) => Object.keys(rules)))];
+
+const ruleTotal = (matrix: Matrix, rule: string): number => Object.values(matrix).reduce((sum, rules) => sum + (rules[rule] ?? 0), 0);
+
+const areasByWeight = (matrix: Matrix): string[] =>
+  Object.entries(matrix)
+    .sort(([leftName, left], [rightName, right]) => totalOf(right) - totalOf(left) || leftName.localeCompare(rightName))
+    .map(([area]) => area);
+
+const sectionOf = (title: string, matrix: Matrix): ReportSection[] => {
+  const total = matrixTotal(matrix);
+  if (total === 0) return [];
+  const areas = areasByWeight(matrix);
+  const rows = rulesIn(matrix)
+    .map((rule) => ({ rule, total: ruleTotal(matrix, rule), counts: areas.map((area) => matrix[area]?.[rule] ?? 0) }))
+    .sort((left, right) => right.total - left.total || left.rule.localeCompare(right.rule));
+  return [{ title, total, areas, rows }];
+};
+
+const errorList = (errors: Readonly<Record<string, number>>): { rule: string; count: number }[] =>
+  Object.entries(errors)
+    .map(([rule, count]) => ({ rule, count }))
+    .sort((left, right) => right.count - left.count || left.rule.localeCompare(right.rule));
+
+/**
+ * `counts` is null when ESLint could not run, and the ratchet file alone still answers the question
+ * the report exists for — where the debt is. Warnings are the half that only a lint run can see:
+ * ESLint's suppressions cover errors, so a warning is never recorded anywhere per rule.
+ */
+type Resolved = {
+  errors: Record<string, number>;
+  warningTotal: number;
+  warningMatrix: Matrix;
+  suppressedMatrix: Matrix;
+  files: number;
+};
+
+/** Every fallback in one place, so the report itself reads as what it reports rather than as defaults. */
+const resolve = (counts: RuleCounts | null, suppressions: readonly Suppression[]): Resolved => ({
+  errors: counts?.errors ?? {},
+  warningTotal: totalOf(counts?.warnings ?? {}),
+  warningMatrix: counts?.areas?.warnings ?? {},
+  suppressedMatrix: counts?.areas?.suppressed ?? matrixFromSuppressions(suppressions),
+  files: counts?.files ?? 0,
+});
+
+export const buildLintReport = (counts: RuleCounts | null, suppressions: readonly Suppression[], lintFailure: string | null = null): LintReport => {
+  const resolved = resolve(counts, suppressions);
+  return {
+    errorTotal: totalOf(resolved.errors),
+    warningTotal: resolved.warningTotal,
+    suppressedTotal: matrixTotal(resolved.suppressedMatrix),
+    files: resolved.files,
+    errors: errorList(resolved.errors),
+    sections: [
+      ...sectionOf("Backlog — suppressed, drains rule by rule", resolved.suppressedMatrix),
+      ...sectionOf("Warnings — never suppressed, so these never drain on their own", resolved.warningMatrix),
+    ],
+    lintFailure: counts === null ? (lintFailure ?? "ESLint did not run") : null,
+  };
+};

--- a/src/render/lintReport.ts
+++ b/src/render/lintReport.ts
@@ -4,7 +4,13 @@ const ROWS_SHOWN = 12;
 const AREAS_SHOWN = 6;
 const BAR_WIDTH = 24;
 
-const bar = (count: number, largest: number): string => "█".repeat(largest === 0 ? 0 : Math.max(1, Math.round((count / largest) * BAR_WIDTH)));
+/**
+ * The `max(1, …)` is so a rule with one finding beside a rule with five hundred still draws
+ * something — but it has to come after the zero check, or a row of zero draws a block and reads as
+ * the smallest non-empty rule in the table.
+ */
+const bar = (count: number, largest: number): string =>
+  count === 0 || largest === 0 ? "" : "█".repeat(Math.max(1, Math.round((count / largest) * BAR_WIDTH)));
 
 /** Columns beyond the cap are summed into one that says so, rather than dropped. */
 const columnsOf = (section: ReportSection): { headings: string[]; countsOf: (counts: readonly number[]) => number[] } => {

--- a/src/render/lintReport.ts
+++ b/src/render/lintReport.ts
@@ -1,0 +1,56 @@
+import type { LintReport, ReportSection } from "../lintReport.ts";
+
+const ROWS_SHOWN = 12;
+const AREAS_SHOWN = 6;
+const BAR_WIDTH = 24;
+
+const bar = (count: number, largest: number): string => "█".repeat(largest === 0 ? 0 : Math.max(1, Math.round((count / largest) * BAR_WIDTH)));
+
+/** Columns beyond the cap are summed into one that says so, rather than dropped. */
+const columnsOf = (section: ReportSection): { headings: string[]; countsOf: (counts: readonly number[]) => number[] } => {
+  if (section.areas.length <= AREAS_SHOWN) return { headings: section.areas, countsOf: (counts) => [...counts] };
+  const hidden = section.areas.length - AREAS_SHOWN;
+  return {
+    headings: [...section.areas.slice(0, AREAS_SHOWN), `${hidden} more`],
+    countsOf: (counts) => [...counts.slice(0, AREAS_SHOWN), counts.slice(AREAS_SHOWN).reduce((sum, count) => sum + count, 0)],
+  };
+};
+
+const renderSection = (section: ReportSection): string[] => {
+  const { headings, countsOf } = columnsOf(section);
+  const shown = section.rows.slice(0, ROWS_SHOWN);
+  const largest = shown[0]?.total ?? 0;
+  return [
+    "",
+    `### ${section.title} — ${section.total}`,
+    "",
+    `| rule | ${headings.join(" | ")} | total | |`,
+    `|---|${headings.map(() => "--:").join("|")}|--:|---|`,
+    ...shown.map((row) => `| \`${row.rule}\` | ${countsOf(row.counts).join(" | ")} | **${row.total}** | ${bar(row.total, largest)} |`),
+    ...(section.rows.length > ROWS_SHOWN ? ["", `${section.rows.length - ROWS_SHOWN} more rules not shown.`] : []),
+  ];
+};
+
+const headline = (report: LintReport): string => {
+  const parts = [`${report.suppressedTotal} suppressed`, `${report.warningTotal} warnings`, `${report.errorTotal} errors`];
+  return `## Lint findings — ${parts.join(", ")}`;
+};
+
+const errorLines = (report: LintReport): string[] => {
+  if (report.errors.length === 0) return [];
+  return ["", "### Errors — nothing recorded these, so they are new", "", ...report.errors.map((entry) => `- \`${entry.rule}\` — ${entry.count}`)];
+};
+
+const preface = (report: LintReport): string[] => {
+  // "No warnings" and "nobody looked for warnings" render identically otherwise, and only one of
+  // them is good news.
+  if (report.lintFailure !== null) return ["", `**This is the ratchet file alone — warnings are not in it.** ESLint did not run: ${report.lintFailure}`];
+  return report.files > 0 ? ["", `${report.files} files linted.`] : [];
+};
+
+export const renderLintReport = (report: LintReport): string => {
+  if (report.sections.length === 0 && report.errors.length === 0) {
+    return [headline(report), "", "Nothing to report — no suppressions, no warnings, no errors.", ""].join("\n");
+  }
+  return [headline(report), ...preface(report), ...errorLines(report), ...report.sections.flatMap(renderSection), ""].join("\n");
+};

--- a/test/test_lintReport.ts
+++ b/test/test_lintReport.ts
@@ -110,6 +110,21 @@ describe("renderLintReport", () => {
     assert.match(markdown, /\| `max-lines` \| 7 \| \*\*7\*\* \| █+ \|/);
   });
 
+  /** `max(1, …)` gives a one-finding rule a visible bar; applied to zero it invents one. */
+  it("draws no bar for a rule with nothing in it", () => {
+    const markdown = renderLintReport(buildLintReport(counts({ areas: { errors: {}, warnings: {}, suppressed: { src: { big: 5, none: 0 } } } }), []));
+    const rowFor = (rule: string): string => markdown.split("\n").find((line) => line.includes(`\`${rule}\``)) ?? "";
+    assert.match(rowFor("big"), /█/);
+    assert.doesNotMatch(rowFor("none"), /█/);
+  });
+
+  /** Every count zero means nothing to report, not a section with an empty table in it. */
+  it("drops a section whose every count is zero", () => {
+    const report = buildLintReport(counts({ areas: { errors: {}, warnings: {}, suppressed: { src: { none: 0 } } } }), []);
+    assert.deepEqual(report.sections, []);
+    assert.match(renderLintReport(report), /Nothing to report/);
+  });
+
   /** A table that silently showed its first rows would read as the whole list. */
   it("says how many rows and areas it did not show", () => {
     const suppressed = Object.fromEntries(Array.from({ length: 9 }, (_, index) => [`area${index}`, { [`rule${index}`]: index + 1 }]));

--- a/test/test_lintReport.ts
+++ b/test/test_lintReport.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { RuleCounts } from "../src/eslintRunner.ts";
+import { areaOf, buildLintReport, matrixFromSuppressions } from "../src/lintReport.ts";
+import { renderLintReport } from "../src/render/lintReport.ts";
+import type { Suppression } from "../src/suppressionsFile.ts";
+
+const counts = (overrides: Partial<RuleCounts> = {}): RuleCounts => ({
+  errors: {},
+  warnings: {},
+  suppressed: {},
+  files: 10,
+  ...overrides,
+});
+
+const entry = (file: string, rule: string, count: number): Suppression => ({ file, rule, count });
+
+describe("areaOf", () => {
+  it("is the top-level directory", () => {
+    assert.equal(areaOf("src/util/text.ts"), "src");
+    assert.equal(areaOf("test/a.ts"), "test");
+  });
+
+  it("names the repository root rather than returning nothing", () => {
+    assert.equal(areaOf("eslint.config.js"), "(root)");
+    assert.equal(areaOf(""), "(root)");
+  });
+});
+
+describe("matrixFromSuppressions", () => {
+  it("folds file counts up into their area", () => {
+    const matrix = matrixFromSuppressions([entry("src/a.ts", "no-var", 2), entry("src/b.ts", "no-var", 3), entry("test/c.ts", "no-var", 1)]);
+    assert.deepEqual(matrix, { src: { "no-var": 5 }, test: { "no-var": 1 } });
+  });
+});
+
+describe("buildLintReport", () => {
+  /** The point of the whole command: the same rule in two places is two different jobs. */
+  it("puts rules against areas, heaviest rule first", () => {
+    const report = buildLintReport(
+      counts({
+        areas: { errors: {}, warnings: {}, suppressed: { src: { "max-lines": 7, complexity: 1 }, test: { complexity: 4 } } },
+      }),
+      [],
+    );
+    const section = report.sections[0];
+    assert.equal(section?.title.startsWith("Backlog"), true);
+    assert.deepEqual(section?.areas, ["src", "test"]);
+    assert.deepEqual(
+      section?.rows.map((row) => [row.rule, row.total, row.counts]),
+      [
+        ["max-lines", 7, [7, 0]],
+        ["complexity", 5, [1, 4]],
+      ],
+    );
+  });
+
+  /**
+   * Warnings are the population nothing else maps: ESLint's suppressions cover errors only, so the
+   * ledger holds one grand total for them and no rule ever appears.
+   */
+  it("gives warnings their own section", () => {
+    const report = buildLintReport(counts({ warnings: { camelcase: 3 }, areas: { errors: {}, warnings: { src: { camelcase: 3 } }, suppressed: {} } }), []);
+    assert.equal(report.warningTotal, 3);
+    assert.equal(report.sections.length, 1);
+    assert.match(report.sections[0]?.title ?? "", /never suppressed/);
+  });
+
+  it("lists errors as totals rather than a matrix", () => {
+    const report = buildLintReport(counts({ errors: { "no-var": 2, "no-debugger": 5 } }), []);
+    assert.deepEqual(report.errors, [
+      { rule: "no-debugger", count: 5 },
+      { rule: "no-var", count: 2 },
+    ]);
+  });
+
+  it("falls back to the ratchet file when ESLint could not run", () => {
+    const report = buildLintReport(null, [entry("src/a.ts", "no-var", 2)], "eslint is not installed");
+    assert.equal(report.suppressedTotal, 2);
+    assert.equal(report.lintFailure, "eslint is not installed");
+    assert.equal(report.warningTotal, 0);
+  });
+
+  it("does not claim a lint failure when the lint succeeded and found nothing", () => {
+    assert.equal(buildLintReport(counts(), []).lintFailure, null);
+  });
+
+  /** A lint run's own area data wins: the ratchet file cannot see warnings at all. */
+  it("prefers the lint run's suppressed matrix over the file", () => {
+    const report = buildLintReport(counts({ areas: { errors: {}, warnings: {}, suppressed: { src: { "no-var": 9 } } } }), [entry("test/a.ts", "no-var", 1)]);
+    assert.deepEqual(report.sections[0]?.areas, ["src"]);
+    assert.equal(report.suppressedTotal, 9);
+  });
+});
+
+describe("renderLintReport", () => {
+  it("says so plainly when there is nothing to report", () => {
+    assert.match(renderLintReport(buildLintReport(counts(), [])), /Nothing to report/);
+  });
+
+  it("marks a backlog-only report so it cannot read as a clean lint", () => {
+    const markdown = renderLintReport(buildLintReport(null, [entry("src/a.ts", "no-var", 1)], "eslint is not installed"));
+    assert.match(markdown, /ratchet file alone/);
+    assert.match(markdown, /eslint is not installed/);
+  });
+
+  it("renders a table a human can read", () => {
+    const markdown = renderLintReport(buildLintReport(counts({ areas: { errors: {}, warnings: {}, suppressed: { src: { "max-lines": 7 } } } }), []));
+    assert.match(markdown, /\| rule \| src \| total \| \|/);
+    assert.match(markdown, /\| `max-lines` \| 7 \| \*\*7\*\* \| █+ \|/);
+  });
+
+  /** A table that silently showed its first rows would read as the whole list. */
+  it("says how many rows and areas it did not show", () => {
+    const suppressed = Object.fromEntries(Array.from({ length: 9 }, (_, index) => [`area${index}`, { [`rule${index}`]: index + 1 }]));
+    const markdown = renderLintReport(buildLintReport(counts({ areas: { errors: {}, warnings: {}, suppressed } }), []));
+    assert.match(markdown, /3 more/);
+  });
+});

--- a/test/test_render.ts
+++ b/test/test_render.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import { renderEslintConfig } from "../src/generate/eslintConfig.ts";
 import { renderCodexReviewWorkflow } from "../src/generate/codexReview.ts";
 import { renderWorkflow } from "../src/generate/workflow.ts";
+import { renderGateWorkflow } from "../src/generate/gateWorkflow.ts";
 import { extractNotes, NOTES_END, NOTES_START, renderQuality } from "../src/render/quality.ts";
 import { applyRuleCounts, emptyState } from "../src/state.ts";
 import type { Freshness } from "../src/freshness.ts";
@@ -346,5 +347,34 @@ describe("renderCodexReviewWorkflow", () => {
 
   it("cancels a superseded run rather than reviewing every push", () => {
     assert.match(workflow, /cancel-in-progress: true/);
+  });
+});
+
+describe("renderGateWorkflow", () => {
+  const gate = (): string => renderGateWorkflow("yarn", "24");
+
+  it("runs the gate", () => {
+    assert.match(gate(), /npx --yes ever-better check --no-write/);
+  });
+
+  /**
+   * The report step is deliberately `if: always()` — the run where `check` has just failed is the
+   * run where the shape of the backlog is worth most, and a step without it would be skipped on
+   * exactly that run.
+   */
+  it("still reports after the gate has failed", () => {
+    const yaml = gate();
+    const reportStep = yaml.slice(yaml.indexOf("- name: ever-better report"));
+    assert.match(reportStep, /if: always\(\)/);
+    assert.match(reportStep, /npx --yes ever-better report/);
+  });
+
+  it("keeps the report after the gate, so a failure is reported before it is explained", () => {
+    const yaml = gate();
+    assert.ok(yaml.indexOf("ever-better check --no-write") < yaml.indexOf("ever-better report"));
+  });
+
+  it("asks for no permissions beyond reading the repository", () => {
+    assert.match(gate(), /permissions:\n {2}contents: read/);
   });
 });

--- a/test/test_report.ts
+++ b/test/test_report.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { after, before, describe, it } from "node:test";
+import { runReport } from "../src/commands/report.ts";
+
+const SUMMARY = "GITHUB_STEP_SUMMARY";
+
+/**
+ * The command promises it is not a gate: it never changes an exit code, and it degrades rather than
+ * throwing when ESLint cannot run or the summary cannot be written. Those are the two `catch`es in
+ * the file, and neither is reachable from the pure tests.
+ */
+describe("ever-better report", () => {
+  let repo = "";
+  const original = process.env[SUMMARY];
+
+  before(async () => {
+    repo = await mkdtemp(path.join(tmpdir(), "ever-better-report-"));
+    await writeFile(
+      path.join(repo, "eslint-suppressions.json"),
+      JSON.stringify({ "src/a.ts": { "no-var": { count: 2 } }, "test/b.ts": { "max-depth": { count: 1 } } }),
+      "utf8",
+    );
+  });
+
+  after(async () => {
+    if (original === undefined) delete process.env[SUMMARY];
+    else process.env[SUMMARY] = original;
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  it("reports the backlog from the ratchet file when ESLint cannot run", async () => {
+    delete process.env[SUMMARY];
+    const markdown = await runReport({ cwd: repo, json: false });
+    assert.match(markdown, /3 suppressed/);
+    assert.match(markdown, /ratchet file alone/);
+    assert.match(markdown, /\| `no-var` \|/);
+  });
+
+  it("appends to the step summary when Actions asks for one", async () => {
+    const summary = path.join(repo, "summary.md");
+    process.env[SUMMARY] = summary;
+    const markdown = await runReport({ cwd: repo, json: false });
+    assert.equal(await readFile(summary, "utf8"), `${markdown}\n`);
+  });
+
+  it("appends rather than replacing, so other steps keep theirs", async () => {
+    const summary = path.join(repo, "shared.md");
+    await writeFile(summary, "## an earlier step\n", "utf8");
+    process.env[SUMMARY] = summary;
+    await runReport({ cwd: repo, json: false });
+    assert.match(await readFile(summary, "utf8"), /^## an earlier step\n/);
+  });
+
+  /** Outside Actions the variable is unset and a terminal run must leave nothing behind. */
+  it("writes no summary when Actions did not ask for one", async () => {
+    const summary = path.join(repo, "once.md");
+    process.env[SUMMARY] = summary;
+    await runReport({ cwd: repo, json: false });
+    const afterFirst = await readFile(summary, "utf8");
+
+    delete process.env[SUMMARY];
+    await runReport({ cwd: repo, json: false });
+    assert.equal(await readFile(summary, "utf8"), afterFirst, "the second run appended with no summary requested");
+  });
+
+  /** A report that failed the job because it could not write its own summary would be a gate. */
+  it("still returns the report when the summary cannot be written", async () => {
+    process.env[SUMMARY] = path.join(repo, "no-such-directory", "summary.md");
+    const markdown = await runReport({ cwd: repo, json: false });
+    assert.match(markdown, /Lint findings/);
+  });
+
+  it("emits parseable JSON, and does not touch the summary for it", async () => {
+    const summary = path.join(repo, "json.md");
+    process.env[SUMMARY] = summary;
+    const output = await runReport({ cwd: repo, json: true });
+    const parsed: unknown = JSON.parse(output);
+    assert.ok(typeof parsed === "object" && parsed !== null);
+    await assert.rejects(readFile(summary, "utf8"));
+  });
+});

--- a/test/test_ruleCountsFormatter.ts
+++ b/test/test_ruleCountsFormatter.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { formatterPath } from "../src/eslintRunner.ts";
+
+type Message = { ruleId: string | null; severity: number; line?: number; message?: string };
+type Result = { filePath: string; messages: Message[]; suppressedMessages?: Message[] };
+type Formatter = (results: readonly Result[], context?: { cwd: string }) => string;
+
+const CWD = "/repo";
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null;
+
+const isFormatterModule = (value: unknown): value is { default: Formatter } => isRecord(value) && typeof value["default"] === "function";
+
+const load = async (): Promise<Formatter> => {
+  const loaded: unknown = await import(path.resolve(formatterPath()));
+  assert.ok(isFormatterModule(loaded), "the formatter has no default export");
+  return loaded.default;
+};
+
+const file = (relative: string, messages: Message[], suppressed: Message[] = []): Result => ({
+  filePath: path.join(CWD, relative),
+  messages,
+  suppressedMessages: suppressed,
+});
+
+const error = (ruleId: string | null): Message => ({ ruleId, severity: 2 });
+const warning = (ruleId: string): Message => ({ ruleId, severity: 1 });
+
+const report = async (results: readonly Result[]): Promise<Record<string, unknown>> => {
+  const formatter = await load();
+  const parsed: unknown = JSON.parse(formatter(results, { cwd: CWD }));
+  assert.ok(isRecord(parsed), "the formatter did not emit an object");
+  return parsed;
+};
+
+/**
+ * The formatter every count in this tool comes from — `freeze`, `prune` and `check` all read it —
+ * and it had no test of its own. It is a plain function of its arguments, so it is driven directly
+ * rather than through a lint run.
+ */
+describe("rule-counts formatter", () => {
+  it("separates the three buckets, which mean three different things", async () => {
+    const parsed = await report([file("src/a.ts", [error("no-var"), warning("camelcase")], [error("max-lines")])]);
+    assert.deepEqual(parsed["errors"], { "no-var": 1 });
+    assert.deepEqual(parsed["warnings"], { camelcase: 1 });
+    assert.deepEqual(parsed["suppressed"], { "max-lines": 1 });
+    assert.equal(parsed["files"], 1);
+  });
+
+  it("names an unattributed error rather than counting it into nothing", async () => {
+    const parsed = await report([file("src/a.ts", [{ ruleId: null, severity: 2, line: 3, message: "Parsing error" }])]);
+    assert.deepEqual(parsed["errors"], { "(parse error)": 1 });
+    assert.deepEqual(parsed["unattributed"], [{ file: path.join(CWD, "src/a.ts"), line: 3, message: "Parsing error" }]);
+  });
+
+  it("caps the unattributed sample so the output stays a constant size", async () => {
+    const parse = (): Message => ({ ruleId: null, severity: 2, line: 1, message: "Parsing error" });
+    const parsed = await report([file("src/a.ts", [parse(), parse(), parse(), parse(), parse()])]);
+    const sample = parsed["unattributed"];
+    assert.ok(Array.isArray(sample));
+    assert.equal(sample.length, 3);
+    assert.deepEqual(parsed["errors"], { "(parse error)": 5 });
+  });
+});
+
+describe("rule-counts formatter, by area", () => {
+  it("groups by the top-level directory", async () => {
+    const parsed = await report([
+      file("src/a.ts", [warning("camelcase")]),
+      file("src/nested/deep/b.ts", [warning("camelcase")]),
+      file("test/c.ts", [warning("camelcase")]),
+    ]);
+    assert.deepEqual(parsed["areas"], {
+      errors: {},
+      warnings: { src: { camelcase: 2 }, test: { camelcase: 1 } },
+      suppressed: {},
+    });
+  });
+
+  it("calls a file at the repository root what it is", async () => {
+    const parsed = await report([file("eslint.config.js", [warning("camelcase")])]);
+    assert.deepEqual(parsed["areas"], { errors: {}, warnings: { "(root)": { camelcase: 1 } }, suppressed: {} });
+  });
+
+  it("breaks suppressed violations down as well, since they are the backlog", async () => {
+    const parsed = await report([file("server/a.ts", [], [error("max-lines"), error("max-lines"), error("complexity")])]);
+    assert.deepEqual(parsed["areas"], {
+      errors: {},
+      warnings: {},
+      suppressed: { server: { "max-lines": 2, complexity: 1 } },
+    });
+  });
+
+  /** Bounded by areas x rules is the whole reason this is computed here rather than from JSON. */
+  it("stays the same size however many violations there are", async () => {
+    const many = Array.from({ length: 500 }, () => warning("camelcase"));
+    const parsed = await report([file("src/a.ts", many)]);
+    assert.deepEqual(parsed["areas"], { errors: {}, warnings: { src: { camelcase: 500 } }, suppressed: {} });
+  });
+});

--- a/test/test_ruleCountsFormatter.ts
+++ b/test/test_ruleCountsFormatter.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, it } from "node:test";
 import { formatterPath } from "../src/eslintRunner.ts";
 
@@ -13,8 +14,14 @@ const isRecord = (value: unknown): value is Record<string, unknown> => typeof va
 
 const isFormatterModule = (value: unknown): value is { default: Formatter } => isRecord(value) && typeof value["default"] === "function";
 
+/**
+ * `pathToFileURL`, not the path. On Windows an absolute path starts with a drive letter, and the
+ * ESM loader reads `D:` as a URL scheme it does not support — a failure that cannot happen on the
+ * machine this was written on. ESLint itself takes the plain path via `--format`, so only the test
+ * needs the URL.
+ */
 const load = async (): Promise<Formatter> => {
-  const loaded: unknown = await import(path.resolve(formatterPath()));
+  const loaded: unknown = await import(pathToFileURL(formatterPath()).href);
   assert.ok(isFormatterModule(loaded), "the formatter has no default export");
   return loaded.default;
 };


### PR DESCRIPTION
## Summary

`eslint .` names files. `status` gives per-rule totals. `next` ranks what to take first. None of them says **which parts of the repo carry which rules** — the shape of the debt rather than its size.

`ever-better report` prints that as markdown, and appends it to `$GITHUB_STEP_SUMMARY` when that is set, which is what makes it a CI report without anyone editing a workflow.

```
## Lint findings — 6 suppressed, 0 warnings, 0 errors

### Backlog — suppressed, drains rule by rule — 6

| rule | src | (root) | total | |
|---|--:|--:|--:|---|
| `no-var` | 3 | 0 | **3** | ████████████████████████ |
| `max-depth` | 1 | 1 | **2** | ████████████████ |
```

Closes #49. Adapted from receptron/mulmoterminal#1647, which is where the formatter-not-a-second-lint-run idea comes from.

## Items to Confirm / Review

1. **`formatters/rule-counts.js` is on the critical path of `freeze`, `prune` and `check`, and had no test at all.** That is the risky part of this diff. It now has seven, driven directly as the pure function it is, and the change to it is additive — one new key. Worth a second opinion that a formatter change cannot take the gate with it.
2. **Warnings are the reason this exists, and that argument is the one to check.** ESLint's suppressions cover *errors* only, so a warning is never grandfathered and never drains. `freeze` puts the entire warning population into one counter (`setCounter(..., totalOf(counts.warnings))`) with no rules behind it. If that reading is wrong, half the value of this command is wrong with it.
3. **The generated workflow gained a step**, so every repo bootstrapped after this gets it. `if: always()` is deliberate — a plain step is skipped exactly on the run where `check` failed, which is the run where the backlog matters most.
4. **Area = top-level directory**, with root files as `(root)`. Crude, and it is the same choice mulmoterminal made. A monorepo would want `packages/*` instead, which is #30's problem.
5. **Errors get totals, not a matrix.** After a freeze an unsuppressed error is new by definition, so there are few of them and ESLint's own output already names the file and line.

## User Prompt

- https://github.com/receptron/mulmoterminal/pull/1647 を取り込みたい。CI で lint レポート出す
- （レポート対象について）両方 — CI が落とす未抑制の分と、`eslint-suppressions.json` が抱えるバックログ

## Why the area dimension is computed in the formatter

The reason is already written at the top of that file for the counts: `--format json` grows with the number of violations, and the first run on an untouched repository is when it is largest. The same argument applies here, so the breakdown is aggregated in the same place and what crosses the process boundary stays bounded by areas × rules however bad the repo is.

The formatter contract was verified against ESLint 10.8.1 rather than read from docs — a probe formatter reports `context` keys `["cwd", "rulesMeta"]`, an absolute `result.filePath`, and a real `suppressedMessages` array.

## Not a gate

It cannot change an exit code. It does not fail when the step summary cannot be written. And when ESLint cannot run at all it falls back to `eslint-suppressions.json` and says so in the output, because "no warnings" and "nobody looked for warnings" must not render the same way:

```
**This is the ratchet file alone — warnings are not in it.** ESLint did not run: eslint is not
installed in this repository. Run `ever-better bootstrap` first.
```

## Verification

**Against real ESLint**, not a hand-built fixture — the extended formatter through an actual lint run, with the totals cross-checked against the breakdown:

```
errors:   { "no-var": 3 }          areas.errors:   src 1, test 1, server 1
warnings: { "camelcase": 4 }       areas.warnings: src 2, server 2
```

**The command against two real repositories**: this one (empty backlog, 7 unsuppressed errors — which is how I found that I had shipped `as` casts into a test file, since this repo bans them) and a scratch fixture with a real `--suppress-all` baseline and no ESLint installed, which exercises the fallback path.

**Break-verified**, each mutation reverted afterwards with the file checksummed back:

| mutation | result |
| --- | --- |
| formatter stops filling `areas` | 8 failing |
| root files lose their area name | 4 failing |
| the lint run's area data is ignored | 11 failing |
| a failed lint reads as a clean one | 7 failing |
| the report step loses `if: always()` | 4 failing |

`format` / `lint` / `typecheck` / `build` / `test` (316 pass) / `knip`, exit codes checked rather than piped. `yarn docs` regenerated — the samples page carries the new workflow step. The **committed** tree was extracted with `git archive` and typechecked on its own, not just the working copy.

work in ever-better