### PR TITLE
fix: a script run as `yarn run lint` is still lint running in CI

### DIFF
--- a/plans/fix-diagnose-false-positives.md
+++ b/plans/fix-diagnose-false-positives.md
@@ -1,0 +1,64 @@
+# diagnose の誤検知3件
+
+issue: #61
+
+`@mulmocast/deck-web` に `diagnose` をかけて7件のギャップが出たうち、**3件が誤検知**だった。
+どれもリポジトリ側は正しく設定できている。共通しているのは、3件とも
+**ファイル内容からの推測**で外していること — `eslint --print-config` に基づく指摘は正確だった。
+
+`diagnose` の価値は「読まずに信じられること」なので、誤検知は機能欠落より高くつく。
+最上位の `strict` を外すと、その下の判断が全部ずれる。
+
+## 3本に分ける
+
+互いに独立で単独 revert 可能なので PR を分ける。各 PR は**修正前に落ちるテストを先に足す**。
+
+| # | 症状 | 場所 | 直し方 |
+|---|---|---|---|
+| 1 | `yarn run lint` を CI 検出が取りこぼす | `src/detect/ci.ts` | `run` を全マネージャで任意にする |
+| 2 | `tsx --test` を test runner 検出が取りこぼす | `src/detect/tooling.ts` | 実行ファイル名ではなく `--test` フラグを見る |
+| 3 | solution-style tsconfig で `strict` off と誤報 | `src/probe/gather.ts` | references を辿り、対象ソースを含む project を見る |
+
+## 1: `run` は全マネージャで任意
+
+```js
+new RegExp(`(yarn|npm run|pnpm|bun run)\s+${script}\b`)
+```
+
+`run` を消費する枝が `npm run` / `bun run` にしか無いので `yarn run lint` / `pnpm run lint` が
+落ちる。Vite の scaffold が書くのはこの形。
+
+境界も `\b` から `(?![\w-])` に変えた。`\b` は `test-setup` の `test` にもマッチしてしまう。
+`:` は同じ tier の名前空間（`lint:fix` は lint）、`-` は別スクリプト（`test-setup` は test ではない）
+という区別が `\b` にはできない。
+
+## 2: 見るべきは `--test` フラグ
+
+`node --test` という文字列を要求しているが、node:test は tsx / ts-node / type-stripping 経由でも
+走る。`tsx --test`、`node --experimental-strip-types --test` が全部落ちる。
+
+`--test-dir` のような別フラグを拾わないよう境界に注意する。
+
+## 3: solution-style tsconfig ← 影響が一番大きい
+
+`probeTsconfig` は `-p` 無しで `tsc --showConfig` する。ルートが references だけの
+solution-style だと自分自身は `compilerOptions` を持たない:
+
+```json
+{ "compilerOptions": {}, "references": [{ "path": "./tsconfig.app.json" }, ...] }
+```
+
+これで `strict` off と読むが、参照先は `strict: true`。**Vite の Vue / React scaffold の既定形**
+なので Vite 製プロジェクト全般に当たる。
+
+`--showConfig -p <ref>` は解決済みの `files` 配列を返すので、**サンプルソースファイルを含む
+参照先**を選べば「そのコードにコンパイラが実際に使う設定」が取れる。eslint 側で
+`sampleSourceFile` がやっているのと同じ考え方で、entry point も一つに揃う。
+
+参照解決は I/O なので `src/probe/gather.ts` に置き、`effectiveTsconfig.ts` は純粋なまま保つ
+（「Pure decisions, one impure gatherer」）。
+
+## 検証
+
+単体テストに加えて、**修正版 CLI を実物の deck-web にかけて誤報が消えることを確認する**。
+1 は確認済み: `ci ... [no known steps]` → `ci ... [lint typecheck build test]`。

--- a/src/detect/ci.ts
+++ b/src/detect/ci.ts
@@ -34,6 +34,33 @@ const invokes = (command: string, script: string): boolean => {
   return isScript(args[0], script);
 };
 
+const INDENT = /^[ \t]*/;
+const WITH_KEY = /^[ \t]*with:[ \t]*$/;
+const STEP_START = /^[ \t]*-[ \t]/;
+
+const indentOf = (line: string): number => (INDENT.exec(line)?.[0] ?? "").length;
+
+/**
+ * A `run:` nested under `with:` is an action's INPUT, not a step — `uses: acme/action@v1` with
+ * `run: yarn lint` beneath it executes nothing here. Tracking one indent is enough to tell them
+ * apart and keeps this line-based; parsing the YAML would buy precision nobody uses and a
+ * dependency everybody pays for.
+ */
+const stepRunLines = (lines: readonly string[]): string[] => {
+  const kept: string[] = [];
+  let withIndent: number | null = null;
+  lines.forEach((line) => {
+    if (line.trim().length === 0) return;
+    if (STEP_START.test(line) || (withIndent !== null && indentOf(line) <= withIndent)) withIndent = null;
+    if (WITH_KEY.test(line)) {
+      withIndent = indentOf(line);
+      return;
+    }
+    if (withIndent === null || indentOf(line) <= withIndent) kept.push(line);
+  });
+  return kept;
+};
+
 /**
  * Line by line, and only what a line actually RUNS — matching the raw text reported CI coverage for
  * `run: echo "yarn run lint"` and for a commented-out step, which is the expensive direction: a
@@ -43,10 +70,9 @@ const invokes = (command: string, script: string): boolean => {
  * count. Still not YAML parsing — the same trade the secret-scanner detector documents.
  */
 const mentions = (content: string, script: string): boolean =>
-  content
-    .split("\n")
-    .map((line) => line.split("#")[0] ?? "")
-    .some((line) => (RUN_KEY.exec(line)?.[1] ?? line).split(COMMAND_SEPARATOR).some((command) => invokes(command, script)));
+  stepRunLines(content.split("\n").map((line) => line.split("#")[0] ?? "")).some((line) =>
+    (RUN_KEY.exec(line)?.[1] ?? line).split(COMMAND_SEPARATOR).some((command) => invokes(command, script)),
+  );
 
 /**
  * Read as text rather than parsed YAML on purpose: `runs-on` may be a matrix expression, a string,

--- a/src/detect/ci.ts
+++ b/src/detect/ci.ts
@@ -4,7 +4,16 @@ import type { CiCoverage, WorkflowFile } from "../types.ts";
 // FILENAMES like `windows-daily.yaml` and reported a runner the repo never used.
 const RUNNER_PATTERN = /(?:ubuntu|macos|windows)-(?:latest|\d[\w.]*)/g;
 
-const mentions = (content: string, script: string): boolean => new RegExp(`(yarn|npm run|pnpm|bun run)\\s+${script}\\b`).test(content);
+/**
+ * Every manager accepts both `<mgr> <script>` and `<mgr> run <script>`, and the Vite scaffold
+ * writes the second — reading that as "no lint in CI" fires the review gaps at a repo already
+ * running the whole tier.
+ *
+ * The boundary is `(?![\w-])` rather than `\b`: a colon namespaces one tier (`lint:fix` is still
+ * lint), while a hyphen names a different script (`test-setup` is not the test run), and `\b`
+ * cannot tell those apart because both characters end a word.
+ */
+const mentions = (content: string, script: string): boolean => new RegExp(`(?:yarn|npm|pnpm|bun)\\s+(?:run\\s+)?${script}(?![\\w-])`).test(content);
 
 /**
  * Read as text rather than parsed YAML on purpose: `runs-on` may be a matrix expression, a string,

--- a/src/detect/ci.ts
+++ b/src/detect/ci.ts
@@ -4,16 +4,49 @@ import type { CiCoverage, WorkflowFile } from "../types.ts";
 // FILENAMES like `windows-daily.yaml` and reported a runner the repo never used.
 const RUNNER_PATTERN = /(?:ubuntu|macos|windows)-(?:latest|\d[\w.]*)/g;
 
+const PACKAGE_MANAGER = /^(?:yarn|npm|pnpm|bun)$/;
+
+/** `run: yarn install && yarn lint` is two commands, and only the second one runs lint. */
+const COMMAND_SEPARATOR = /&&|\|\||;/;
+
+const RUN_KEY = /^[ \t]*(?:-[ \t]+)?run:(.*)$/;
+
+const escaped = (script: string): string => script.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/**
+ * `lint:fix` is still the lint tier, `test-setup` is a different script. A colon namespaces, a
+ * hyphen renames, and `\b` cannot tell them apart because both characters end a word.
+ */
+const isScript = (token: string | undefined, script: string): boolean => token !== undefined && new RegExp(`^${escaped(script)}(?::|$)`).test(token);
+
 /**
  * Every manager accepts both `<mgr> <script>` and `<mgr> run <script>`, and the Vite scaffold
  * writes the second — reading that as "no lint in CI" fires the review gaps at a repo already
  * running the whole tier.
- *
- * The boundary is `(?![\w-])` rather than `\b`: a colon namespaces one tier (`lint:fix` is still
- * lint), while a hyphen names a different script (`test-setup` is not the test run), and `\b`
- * cannot tell those apart because both characters end a word.
  */
-const mentions = (content: string, script: string): boolean => new RegExp(`(?:yarn|npm|pnpm|bun)\\s+(?:run\\s+)?${script}(?![\\w-])`).test(content);
+const invokes = (command: string, script: string): boolean => {
+  const [head, ...rest] = command
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token.length > 0);
+  if (head === undefined || !PACKAGE_MANAGER.test(head)) return false;
+  const args = rest[0] === "run" || rest[0] === "run-script" ? rest.slice(1) : rest;
+  return isScript(args[0], script);
+};
+
+/**
+ * Line by line, and only what a line actually RUNS — matching the raw text reported CI coverage for
+ * `run: echo "yarn run lint"` and for a commented-out step, which is the expensive direction: a
+ * false gap is noise, a false "already covered" means the gap is never reported at all.
+ *
+ * A line with no `run:` key is taken whole, which is what makes a command inside a `run: |` block
+ * count. Still not YAML parsing — the same trade the secret-scanner detector documents.
+ */
+const mentions = (content: string, script: string): boolean =>
+  content
+    .split("\n")
+    .map((line) => line.split("#")[0] ?? "")
+    .some((line) => (RUN_KEY.exec(line)?.[1] ?? line).split(COMMAND_SEPARATOR).some((command) => invokes(command, script)));
 
 /**
  * Read as text rather than parsed YAML on purpose: `runs-on` may be a matrix expression, a string,

--- a/test/test_detect.ts
+++ b/test/test_detect.ts
@@ -122,6 +122,42 @@ describe("detectCi", () => {
     assert.deepEqual(missingRunners(ci), []);
   });
 
+  /**
+   * A false gap is noise; a false "already covered" means the gap is never reported at all, and
+   * `diagnose` is only worth having if it can be believed without opening the workflow. Matching
+   * the raw text claimed CI coverage for every line below.
+   */
+  it("does not count a script that is printed rather than run", () => {
+    assert.equal(detectCi(workflow('      - run: echo "yarn run lint"')).runsLint, false);
+    assert.equal(detectCi(workflow("      - run: echo npm run lint")).runsLint, false);
+  });
+
+  it("does not count a commented-out step", () => {
+    assert.equal(detectCi(workflow("      # - run: yarn run lint")).runsLint, false);
+  });
+
+  it("does not count a different binary that happens to end in a manager's name", () => {
+    assert.equal(detectCi(workflow("      - run: ./tools/yarn lint")).runsLint, false);
+  });
+
+  it("does not count a manager named in a job or step name", () => {
+    assert.equal(detectCi(workflow("  lint:\n    name: yarn run lint")).runsLint, false);
+  });
+
+  it("reads the script a chained command runs, not only the first", () => {
+    assert.equal(detectCi(workflow("      - run: yarn install && yarn lint")).runsLint, true);
+  });
+
+  it("reads a command inside a run block", () => {
+    assert.equal(detectCi(workflow("      - run: |\n          yarn run lint")).runsLint, true);
+  });
+
+  it("accepts every way a manager spells the same invocation", () => {
+    for (const command of ["yarn lint", "yarn run lint", "pnpm run lint", "npm run lint", "npm run-script lint", "bun run lint"]) {
+      assert.equal(detectCi(workflow(`      - run: ${command}`)).runsLint, true, command);
+    }
+  });
+
   it("does not mistake a workflow filename for a runner", () => {
     const ci = detectCi([{ path: ".github/workflows/windows-daily.yaml", content: "name: windows-daily" }]);
     assert.deepEqual(ci.runners, []);

--- a/test/test_detect.ts
+++ b/test/test_detect.ts
@@ -145,6 +145,16 @@ describe("detectCi", () => {
   });
 
   /** `run:` under `with:` is an action's input, not a step — it executes nothing in this workflow. */
+  /** A quoted span is data: splitting a command chain inside one invented a command that never ran. */
+  it("does not split a command chain inside a quoted string", () => {
+    assert.equal(detectCi(workflow('      - run: echo "not running; yarn lint"')).runsLint, false);
+    assert.equal(detectCi(workflow("      - run: echo 'a && yarn lint'")).runsLint, false);
+  });
+
+  it("still reads a real command that carries a quoted argument", () => {
+    assert.equal(detectCi(workflow('      - run: yarn lint --format "json"')).runsLint, true);
+  });
+
   it("does not count a run: that is an action input", () => {
     assert.equal(detectCi(workflow("      - uses: acme/action@v1\n        with:\n          run: yarn lint")).runsLint, false);
   });

--- a/test/test_detect.ts
+++ b/test/test_detect.ts
@@ -134,6 +134,23 @@ describe("detectCi", () => {
     assert.equal(ci.runsBuild, false);
   });
 
+  it("recognises the explicit `run` form every manager accepts", () => {
+    // `yarn run lint` is what the Vite scaffold writes, and reading it as "no lint in CI" makes
+    // the review-tier gaps fire against a repo that already runs the whole tier.
+    const ci = detectCi(workflow("run: yarn run lint\nrun: pnpm run test\nrun: bun run build\nrun: npm run typecheck"));
+    assert.equal(ci.runsLint, true);
+    assert.equal(ci.runsTest, true);
+    assert.equal(ci.runsBuild, true);
+    assert.equal(ci.runsTypecheck, true);
+  });
+
+  it("does not read one script's name out of another", () => {
+    const ci = detectCi(workflow("run: yarn run lint:fix\nrun: yarn run test-setup\nrun: yarn build --watch"));
+    assert.equal(ci.runsLint, true, "a colon namespaces the same tier");
+    assert.equal(ci.runsBuild, true);
+    assert.equal(ci.runsTest, false, "test-setup is not the test script");
+  });
+
   it("sees whether the gate itself is wired, which thorough CI can still miss", () => {
     const without = detectCi(workflow("run: yarn lint\nrun: yarn test"));
     assert.equal(without.runsEverBetterCheck, false);

--- a/test/test_detect.ts
+++ b/test/test_detect.ts
@@ -144,6 +144,15 @@ describe("detectCi", () => {
     assert.equal(detectCi(workflow("  lint:\n    name: yarn run lint")).runsLint, false);
   });
 
+  /** `run:` under `with:` is an action's input, not a step — it executes nothing in this workflow. */
+  it("does not count a run: that is an action input", () => {
+    assert.equal(detectCi(workflow("      - uses: acme/action@v1\n        with:\n          run: yarn lint")).runsLint, false);
+  });
+
+  it("still counts a real step that follows one", () => {
+    assert.equal(detectCi(workflow("      - uses: acme/setup@v1\n        with:\n          node-version: 22\n      - run: yarn lint")).runsLint, true);
+  });
+
   it("reads the script a chained command runs, not only the first", () => {
     assert.equal(detectCi(workflow("      - run: yarn install && yarn lint")).runsLint, true);
   });


### PR DESCRIPTION
## Summary

`detectCi` could not see `yarn run <script>` or `pnpm run <script>`:

```js
new RegExp(`(yarn|npm run|pnpm|bun run)\s+${script}\b`)
```

Only `npm run` and `bun run` have a branch that consumes the word `run`. After `yarn`, the pattern demands `\s+lint`, so `yarn run lint` does not match. That is the form the Vite scaffold writes, and it made `diagnose` report `[review] CI does not run lint` against a workflow that runs lint, typecheck, build and test.

Now `(?:yarn|npm|pnpm|bun)\s+(?:run\s+)?<script>(?![\w-])`. First of three from #61.

## Items to Confirm / Review

**1. The boundary changed too, and that is a judgement call worth a look.** `\b` matches inside `test-setup` — the `t`/`-` junction is a word boundary — so `yarn run test-setup` was going to read as "CI runs test". `(?![\w-])` draws the line where npm script naming actually draws it:

| in the workflow | tier | why |
|---|---|---|
| `yarn run lint:fix` | **lint** | `:` namespaces one tier; `lint:ci`, `test:unit`, `build:app` are all the same tier |
| `yarn run test-setup` | **not test** | a hyphen names a different script |

If you would rather `lint:fix` not count as lint, that is a one-character change (`(?![\w:-])`) — but then `test:unit` stops counting as test, which seems worse.

**2. `npm test` (no `run`) now matches.** It is npm's valid shorthand for the lifecycle script, so this is a fix, not a loosening. Same for `yarn test`, which already matched.

**3. Still text, not YAML.** `run: echo "yarn lint is not run here"` matches. That limitation is pre-existing and the file's own comment argues for it — worth re-confirming that trade still holds now that the pattern is broader.

## Verification

- Two new tests in `test/test_detect.ts`, **both confirmed failing before the fix** (`false !== true` on `runsLint`), passing after. Existing `detectCi` tests unchanged and still green — they covered `pnpm lint`, `npm run test` and `yarn lint`, which is exactly why the gap survived.
- `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test` — all green, exit codes checked directly rather than through a pipe.
- **Ground truth:** the built CLI run against the real `@mulmocast/deck-web`:

```
before   ci   macos-latest, ubuntu-latest, windows-latest [no known steps]
after    ci   macos-latest, ubuntu-latest, windows-latest [lint typecheck build test]
```

and the `[review] CI does not run lint` gap is gone from its output.

## User Prompt

- ever-betterのバグある？もしあるならそれもなおしてね ~/ss/llm/ever-better