### PR TITLE
fix: node:test is the runner whatever launches node

### DIFF
--- a/src/detect/tooling.ts
+++ b/src/detect/tooling.ts
@@ -116,13 +116,24 @@ export const detectEslintSetup = (rootEntries: readonly string[]): EslintSetup =
  */
 const DEPENDENCY_ONLY_RUNNERS = ["mocha", "ava", "tap", "jasmine"] as const;
 
+/**
+ * node:test is the runner whatever launches node — `tsx --test`, `node --experimental-strip-types
+ * --test`, `ts-node --test` all run it, and matching the string `node --test` saw none of them.
+ * Reporting "none" is not a cosmetic mislabel: bootstrap installs vitest on "none", so a repo that
+ * already tests gets a second runner.
+ *
+ * The lookahead is what keeps `--test-reporter=spec` and `--test-dir=e2e` out — and `node --test`
+ * as a substring matched the first of those, so this reads a flag rather than a command line.
+ */
+const RUNS_NODE_TEST = /(?:^|\s)--test(?=\s|$)/;
+
 export const detectTestRunner = (packageJson: PackageJson | null): TestRunner => {
   if (hasDependency(packageJson, "vitest")) return "vitest";
   if (hasDependency(packageJson, "jest")) return "jest";
   const named = DEPENDENCY_ONLY_RUNNERS.find((runner) => hasDependency(packageJson, runner));
   if (named) return named;
   const testScript = packageJson?.scripts?.["test"] ?? "";
-  if (testScript.includes("node --test") || testScript.includes("node:test")) return "node:test";
+  if (RUNS_NODE_TEST.test(testScript)) return "node:test";
   return "none";
 };
 

--- a/test/test_detect.ts
+++ b/test/test_detect.ts
@@ -84,6 +84,19 @@ describe("detectTestRunner", () => {
     assert.equal(detectTestRunner({ scripts: { test: "node --test test/*.ts" } }), "node:test");
   });
 
+  it("recognises node:test whatever launches node", () => {
+    // Reporting "none" here is what makes it expensive: bootstrap installs vitest on "none", so a
+    // repo already running node:test through tsx gets a second runner added to it.
+    assert.equal(detectTestRunner({ scripts: { test: "tsx --test ./test/**/test_*.ts" } }), "node:test");
+    assert.equal(detectTestRunner({ scripts: { test: "node --experimental-strip-types --test test/*.ts" } }), "node:test");
+    assert.equal(detectTestRunner({ scripts: { test: "node --test-reporter=spec --test test/*.ts" } }), "node:test");
+  });
+
+  it("does not read `--test` out of a longer flag", () => {
+    assert.equal(detectTestRunner({ scripts: { test: "playwright test --test-dir=e2e" } }), "none");
+    assert.equal(detectTestRunner({ scripts: { test: "node --test-reporter=spec build.js" } }), "none");
+  });
+
   it("reports none rather than guessing", () => {
     assert.equal(detectTestRunner({ scripts: { test: "echo nope" } }), "none");
   });


### PR DESCRIPTION
## Summary

`detectTestRunner` matched the literal string `node --test`, so it saw node:test only when node was invoked directly:

```ts
if (testScript.includes("node --test") || testScript.includes("node:test")) return "node:test";
```

`tsx --test`, `node --experimental-strip-types --test` and `ts-node --test` all run node:test and all read as `none`. It now matches the **flag**:

```ts
const RUNS_NODE_TEST = /(?:^|\s)--test(?=\s|$)/;
```

Second of three from #61.

## Items to Confirm / Review

**1. This one has teeth beyond a wrong label.** The existing test in this file already spells out why: *"bootstrap installs vitest on `none`, which puts a second runner into a repo that already tests."* `@mulmocast/deck-web` runs `tsx --test` and was reported as `none`, so `ever-better bootstrap` would have installed vitest alongside its working node:test suite.

**2. It also fixes a false positive nobody had noticed.** `node --test-reporter=spec build.js` contains the substring `node --test`, so the old check called a build script a test runner. The new lookahead rejects both `--test-reporter` and `--test-dir`. There is a test for it.

**3. The `node:test` substring check is gone — please confirm you want that.** It was a proxy for the real signal, and the flag is the real signal. Nothing in the suite covered it, so it is a silent behaviour change rather than a caught one; I removed it rather than keeping both, on the grounds that `"test": "echo see node:test docs"` matching is worse than the case it would rescue. Reinstating it is `|| testScript.includes("node:test")` if you disagree.

**Still not detected** (pre-existing, unchanged): a test script that delegates, e.g. `"test": "npm run test:unit"` where the flag lives in the other script.

## Verification

- Two new tests, **both confirmed failing before the fix** — and the second failed for the false-positive reason above, not the one I wrote it for.
- `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test` — green, exit codes read directly.
- **Ground truth:** built CLI against the real `@mulmocast/deck-web` (`"test": "tsx --test ./test/**/test_*.ts"`):

```
before   test runner   none          + gap: [bootstrap] No test runner
after    test runner   node:test     gap gone
```

## User Prompt

- ever-betterのバグある？もしあるならそれもなおしてね ~/ss/llm/ever-better