### PR TITLE
fix: a solution-style tsconfig holds no options, so read the project that compiles the code

### DIFF
--- a/src/probe/effectiveTsconfig.ts
+++ b/src/probe/effectiveTsconfig.ts
@@ -2,6 +2,10 @@ type CompilerOptions = Record<string, unknown>;
 
 export type ShownConfig = {
   compilerOptions?: CompilerOptions;
+  /** Resolved by `--showConfig`: the files this project actually compiles, as `./`-prefixed paths. */
+  files?: string[];
+  /** Present on a solution-style config, which holds no options of its own. */
+  references?: { path?: string }[];
 };
 
 export type StrictnessFlag = {
@@ -59,4 +63,28 @@ export const isStrictOff = (shown: ShownConfig | null): boolean => {
   if (!shown) return false;
   const options = shown.compilerOptions ?? {};
   return !isEnabled(options["strict"]) && !isEnabled(options["strictNullChecks"]);
+};
+
+const normalise = (filePath: string): string => filePath.replace(/^\.\//, "");
+
+/**
+ * A solution-style root — `{ "files": [], "references": [...] }`, which is what the Vite scaffold
+ * writes — carries no `compilerOptions` of its own, so reading strictness off it reports every
+ * flag as absent while the referenced projects have them on.
+ */
+export const referencePaths = (shown: ShownConfig | null): string[] =>
+  (shown?.references ?? []).map((reference) => reference.path).filter((refPath): refPath is string => typeof refPath === "string");
+
+const covers = (project: ShownConfig, filePath: string): boolean => (project.files ?? []).some((entry) => normalise(entry) === normalise(filePath));
+
+/**
+ * Which referenced project the compiler would really use for the code. Preferring the one that
+ * compiles the sample file is exact; falling back to the widest project keeps an answer when the
+ * sample sits outside every project (a build script, say) rather than reporting nothing.
+ */
+export const projectForSample = (projects: readonly ShownConfig[], samplePath: string | null): ShownConfig | null => {
+  const covering = samplePath === null ? undefined : projects.find((project) => covers(project, samplePath));
+  if (covering) return covering;
+  const widest = [...projects].sort((a, b) => (b.files?.length ?? 0) - (a.files?.length ?? 0));
+  return widest[0] ?? null;
 };

--- a/src/probe/gather.ts
+++ b/src/probe/gather.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { printConfig } from "../eslintRunner.ts";
 import { exec } from "../util/exec.ts";
 import type { PrintedConfig } from "./effectiveRules.ts";
-import type { ShownConfig } from "./effectiveTsconfig.ts";
+import { projectForSample, referencePaths, type ShownConfig } from "./effectiveTsconfig.ts";
 import type { SourceFile } from "../types.ts";
 
 export type Probes = {
@@ -33,14 +33,32 @@ export const sampleSourceFile = (sourceFiles: readonly SourceFile[]): SourceFile
 };
 
 /** `--showConfig` resolves every `extends` first, so it reports what the compiler will really use. */
-const probeTsconfig = async (cwd: string): Promise<ShownConfig | null> => {
+const showConfig = async (cwd: string, project: string | null): Promise<ShownConfig | null> => {
   const entry = path.join(cwd, "node_modules", "typescript", "bin", "tsc");
   try {
-    const result = await exec(process.execPath, [entry, "--showConfig"], cwd);
+    const args = project === null ? ["--showConfig"] : ["--showConfig", "-p", project];
+    const result = await exec(process.execPath, [entry, ...args], cwd);
     return result.code === 0 ? parseObject(result.stdout) : null;
   } catch {
     return null;
   }
+};
+
+/**
+ * A solution-style root — `{ "files": [], "references": [...] }`, which is what the Vite scaffold
+ * writes — resolves to an empty `compilerOptions`, so asking it about strictness reports every
+ * flag off while the referenced projects have them on. Follow the references and answer from the
+ * project that actually compiles the code.
+ *
+ * `--showConfig` does no type checking, so one spawn per reference is cheap and they run together.
+ */
+const probeTsconfig = async (cwd: string, samplePath: string | null): Promise<ShownConfig | null> => {
+  const root = await showConfig(cwd, null);
+  const references = referencePaths(root);
+  if (references.length === 0) return root;
+  const resolved = await Promise.all(references.map((reference) => showConfig(cwd, reference)));
+  const projects = resolved.filter((project): project is ShownConfig => project !== null);
+  return projectForSample(projects, samplePath) ?? root;
 };
 
 /** Both probes shell out, both tolerate absence, and neither is fatal. */
@@ -48,6 +66,6 @@ export const gatherProbes = async (cwd: string, sourceFiles: readonly SourceFile
   const sample = sampleSourceFile(sourceFiles);
   return {
     rules: sample ? await printConfig(cwd, sample.path) : null,
-    tsconfig: await probeTsconfig(cwd),
+    tsconfig: await probeTsconfig(cwd, sample?.path ?? null),
   };
 };

--- a/src/probe/gather.ts
+++ b/src/probe/gather.ts
@@ -44,21 +44,48 @@ const showConfig = async (cwd: string, project: string | null): Promise<ShownCon
   }
 };
 
+/** How deep a chain of solution-style configs is worth following before calling it a loop. */
+const MAX_REFERENCE_DEPTH = 8;
+
+/** A project that compiles something. A solution-style config lists references and no files. */
+const compilesSomething = (project: ShownConfig): boolean => (project.files ?? []).length > 0;
+
+/**
+ * References can point at further solution-style configs — one level of following lands on another
+ * config with no options and reports every strictness flag absent all over again. `seen` guards a
+ * cycle; the depth cap guards a chain nobody meant to write.
+ */
+const collectProjects = async (cwd: string, shown: ShownConfig, seen: Set<string>, depth: number): Promise<ShownConfig[]> => {
+  const here = compilesSomething(shown) ? [shown] : [];
+  if (depth >= MAX_REFERENCE_DEPTH) return here;
+  const next = referencePaths(shown).filter((reference) => !seen.has(reference));
+  next.forEach((reference) => seen.add(reference));
+  const resolved = await Promise.all(next.map((reference) => showConfig(cwd, reference)));
+  const nested = await Promise.all(
+    resolved.filter((project): project is ShownConfig => project !== null).map((project) => collectProjects(cwd, project, seen, depth + 1)),
+  );
+  return [...here, ...nested.flat()];
+};
+
 /**
  * A solution-style root — `{ "files": [], "references": [...] }`, which is what the Vite scaffold
  * writes — resolves to an empty `compilerOptions`, so asking it about strictness reports every
  * flag off while the referenced projects have them on. Follow the references and answer from the
  * project that actually compiles the code.
  *
+ * When nothing resolves — every reference missing, or a chain of solutions with no leaf — the
+ * answer is null rather than the root. Answering from a config that holds no options is exactly
+ * the false report this exists to remove, and `diagnose` treats null as "no finding", which is the
+ * safe direction: a missing gap is noise, a wrong one is an instruction to change something that
+ * is already correct.
+ *
  * `--showConfig` does no type checking, so one spawn per reference is cheap and they run together.
  */
 const probeTsconfig = async (cwd: string, samplePath: string | null): Promise<ShownConfig | null> => {
   const root = await showConfig(cwd, null);
-  const references = referencePaths(root);
-  if (references.length === 0) return root;
-  const resolved = await Promise.all(references.map((reference) => showConfig(cwd, reference)));
-  const projects = resolved.filter((project): project is ShownConfig => project !== null);
-  return projectForSample(projects, samplePath) ?? root;
+  if (root === null || referencePaths(root).length === 0) return root;
+  const projects = await collectProjects(cwd, root, new Set(), 0);
+  return projects.length === 0 ? null : projectForSample(projects, samplePath);
 };
 
 /** Both probes shell out, both tolerate absence, and neither is fatal. */

--- a/test/test_probe.ts
+++ b/test/test_probe.ts
@@ -2,8 +2,14 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { findWeakRules, isRuleOff, isRuleWarnOnly, HIGH_VALUE_RULES } from "../src/probe/effectiveRules.ts";
 import { findMissingStrictness, isStrictOff, projectForSample, referencePaths } from "../src/probe/effectiveTsconfig.ts";
-import { sampleSourceFile } from "../src/probe/gather.ts";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { gatherProbes, sampleSourceFile } from "../src/probe/gather.ts";
 import type { SourceFile } from "../src/types.ts";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 const file = (path: string): SourceFile => ({
   path,
@@ -161,5 +167,64 @@ describe("projectForSample", () => {
 
   it("has nothing to pick from without projects", () => {
     assert.equal(projectForSample([], "src/a.ts"), null);
+  });
+});
+
+describe("probeTsconfig through a solution-style root", () => {
+  const write = async (files: Record<string, string>): Promise<string> => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ever-better-tsconfig-"));
+    await mkdir(path.join(dir, "src"), { recursive: true });
+    await Promise.all(Object.entries(files).map(([name, body]) => writeFile(path.join(dir, name), body, "utf8")));
+    await symlink(path.join(repoRoot, "node_modules"), path.join(dir, "node_modules"));
+    return dir;
+  };
+
+  const APP = JSON.stringify({ compilerOptions: { strict: true, target: "ES2022", module: "ESNext", moduleResolution: "bundler" }, include: ["src"] });
+  const SOURCE = "export const value: number = 1;\n";
+  const strictOf = async (dir: string): Promise<unknown> => {
+    const probes = await gatherProbes(dir, [{ path: "src/main.ts", ext: "ts", lines: 1 }]);
+    return probes.tsconfig?.["compilerOptions"];
+  };
+
+  /**
+   * The Vite scaffold's default shape. The root holds no options of its own, so reading strictness
+   * off it reported every flag absent while the referenced project has them on.
+   */
+  it("answers from the project that compiles the code", async () => {
+    const dir = await write({
+      "tsconfig.json": JSON.stringify({ files: [], references: [{ path: "./tsconfig.app.json" }] }),
+      "tsconfig.app.json": APP,
+      "src/main.ts": SOURCE,
+    });
+    assert.deepEqual(await strictOf(dir), { strict: true, target: "es2022", module: "esnext", moduleResolution: "bundler" });
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  /** One level of following lands on another config with no options and reports the same lie. */
+  it("follows a reference that is itself a solution", async () => {
+    const dir = await write({
+      "tsconfig.json": JSON.stringify({ files: [], references: [{ path: "./tsconfig.mid.json" }] }),
+      "tsconfig.mid.json": JSON.stringify({ files: [], references: [{ path: "./tsconfig.app.json" }] }),
+      "tsconfig.app.json": APP,
+      "src/main.ts": SOURCE,
+    });
+    const options = await strictOf(dir);
+    assert.ok(options !== undefined && options !== null && typeof options === "object" && "strict" in options);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  /**
+   * Answering from a root that holds no options is the false report this exists to remove, so
+   * nothing resolving means no answer — `diagnose` reads that as no finding, which is the safe
+   * direction: a missing gap is noise, a wrong one sends someone to change correct code.
+   */
+  it("reports nothing rather than the empty root when no reference resolves", async () => {
+    const dir = await write({
+      "tsconfig.json": JSON.stringify({ files: [], references: [{ path: "./tsconfig.missing.json" }] }),
+      "src/main.ts": SOURCE,
+    });
+    const probes = await gatherProbes(dir, [{ path: "src/main.ts", ext: "ts", lines: 1 }]);
+    assert.equal(probes.tsconfig, null);
+    await rm(dir, { recursive: true, force: true });
   });
 });

--- a/test/test_probe.ts
+++ b/test/test_probe.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { findWeakRules, isRuleOff, isRuleWarnOnly, HIGH_VALUE_RULES } from "../src/probe/effectiveRules.ts";
-import { findMissingStrictness, isStrictOff } from "../src/probe/effectiveTsconfig.ts";
+import { findMissingStrictness, isStrictOff, projectForSample, referencePaths } from "../src/probe/effectiveTsconfig.ts";
 import { sampleSourceFile } from "../src/probe/gather.ts";
 import type { SourceFile } from "../src/types.ts";
 
@@ -123,5 +123,43 @@ describe("sampleSourceFile", () => {
 
   it("returns null for an empty repo", () => {
     assert.equal(sampleSourceFile([]), null);
+  });
+});
+
+describe("referencePaths", () => {
+  it("lists a solution-style root's projects", () => {
+    const root = { compilerOptions: {}, references: [{ path: "./tsconfig.app.json" }, { path: "./tsconfig.node.json" }] };
+    assert.deepEqual(referencePaths(root), ["./tsconfig.app.json", "./tsconfig.node.json"]);
+  });
+
+  it("is empty for an ordinary config, and for none at all", () => {
+    assert.deepEqual(referencePaths({ compilerOptions: { strict: true } }), []);
+    assert.deepEqual(referencePaths(null), []);
+  });
+});
+
+describe("projectForSample", () => {
+  const app = { compilerOptions: { strict: true }, files: ["./src/a.ts", "./src/b.ts"] };
+  const node = { compilerOptions: {}, files: ["./vite.config.ts"] };
+
+  it("picks the project that compiles the sample", () => {
+    assert.equal(projectForSample([node, app], "src/b.ts"), app);
+    assert.equal(projectForSample([node, app], "vite.config.ts"), node);
+  });
+
+  it("matches whether or not the paths carry a ./ prefix", () => {
+    assert.equal(projectForSample([app], "./src/a.ts"), app);
+    assert.equal(projectForSample([{ compilerOptions: {}, files: ["src/a.ts"] }], "./src/a.ts")?.files?.length, 1);
+  });
+
+  it("falls back to the widest project when the sample is in none of them", () => {
+    // A build script under `scripts/` belongs to no project; answering about the biggest one
+    // beats answering nothing, because nothing reads as "strict is off".
+    assert.equal(projectForSample([node, app], "scripts/build.ts"), app);
+    assert.equal(projectForSample([node, app], null), app);
+  });
+
+  it("has nothing to pick from without projects", () => {
+    assert.equal(projectForSample([], "src/a.ts"), null);
   });
 });


### PR DESCRIPTION
## Summary

`probeTsconfig` ran `tsc --showConfig` with no `-p`, so it read the nearest `tsconfig.json`. When that root is **solution-style** — references only, no options of its own — the answer is:

```json
{ "compilerOptions": {}, "references": [{ "path": "./tsconfig.app.json" }, ...] }
```

`isStrictOff` sees no `strict` and reports **"TypeScript `strict` is off"**, while every referenced project has it on. It now follows the references and answers from the project that actually compiles the code.

Third and last of #61, and the one that matters most: **this is the shape the Vite Vue/React scaffold generates**, so the false positive fires on Vite projects generally — and `strict` is the finding the tool itself calls the one that makes everything below it moot.

## Items to Confirm / Review

**1. Which project to read, when a root has several.** The rule is: the project whose resolved `files` contains the sample source file; failing that, the project compiling the most files. The second half is not hypothetical — on the real repo it is the branch that fired:

```
sample file : scripts/collect_fragment_classes.ts   <- in no project at all
chosen      : tsconfig.app.json  (15 files, ./src/…)  strict: true
```

A build script under `scripts/` belongs to no project, and answering about the widest one beats answering nothing, because nothing reads as "strict is off" — the exact bug being fixed. Both branches have tests and both ran on a real repo.

**2. The split follows the architecture rule.** `referencePaths` and `projectForSample` are pure and live in `effectiveTsconfig.ts` with unit tests; only the extra `--showConfig -p` spawns are in `gather.ts`.

**3. One spawn per reference, in parallel, uncapped.** `--showConfig` does no type checking, so each is cheap. A large monorepo would spawn one per package — that seemed better than a silent cap that truncates the answer, but say if you would rather bound it (#30 tracks monorepos separately).

**4. Non-solution repos cannot regress**: `references.length === 0` returns the root exactly as before. Confirmed against this repo, whose own `tsconfig.json` has no `references` — its diagnose output is unchanged.

**5. Unrelated observation, not fixed here.** `sampleSourceFile` picked `scripts/collect_fragment_classes.ts`, which is outside that repo's `eslint src test`. It also drives `eslint --print-config`, so I checked whether the rule counts were being measured on the wrong file: `--print-config` returns **440 enabled of 889 for both** that script and `src/beatHelpers.ts`, so no harm there. It could matter in a repo with per-directory overrides. Worth its own issue if you agree.

## Verification

- 9 new unit tests over the two pure functions.
- `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test` — green, exit codes read directly.
- **Ground truth**, built CLI against the real `@mulmocast/deck-web` (root is solution-style; `tsconfig.app.json` and `tsconfig.test.json` resolve `strict: true` through `@vue/tsconfig`, `tsconfig.node.json` does not):

```
before   [tighten] TypeScript `strict` is off
after    [tighten] 5 strictness flags `strict` does not include are off
```

The second is the correct finding — strict is on, and five of the flags it does not include are genuinely off.

## User Prompt

- ever-betterのバグある？もしあるならそれもなおしてね ~/ss/llm/ever-better