### PR TITLE
fix: generated files are what Prettier would write

### DIFF
--- a/docs/generated-config.md
+++ b/docs/generated-config.md
@@ -134,10 +134,7 @@ export default tseslint.config(
     rules: {
       // A loop counter and a discarded binding are not what this is aimed at; a variable called
       // `d` holding a customer record is. `js`, `fs`, `os` are the conventional module aliases.
-      "id-length": [
-        "error",
-        { min: 3, exceptions: ["_", "i", "j", "k", "id", "ok", "to", "up", "js", "fs", "os"] },
-      ],
+      "id-length": ["error", { min: 3, exceptions: ["_", "i", "j", "k", "id", "ok", "to", "up", "js", "fs", "os"] }],
     },
   },
   {
@@ -311,10 +308,7 @@ export default tseslint.config(
     rules: {
       // A loop counter and a discarded binding are not what this is aimed at; a variable called
       // `d` holding a customer record is. `js`, `fs`, `os` are the conventional module aliases.
-      "id-length": [
-        "error",
-        { min: 3, exceptions: ["_", "i", "j", "k", "id", "ok", "to", "up", "js", "fs", "os"] },
-      ],
+      "id-length": ["error", { min: 3, exceptions: ["_", "i", "j", "k", "id", "ok", "to", "up", "js", "fs", "os"] }],
     },
   },
   {
@@ -459,10 +453,7 @@ export default tseslint.config(
     rules: {
       // A loop counter and a discarded binding are not what this is aimed at; a variable called
       // `d` holding a customer record is. `js`, `fs`, `os` are the conventional module aliases.
-      "id-length": [
-        "error",
-        { min: 3, exceptions: ["_", "i", "j", "k", "id", "ok", "to", "up", "js", "fs", "os"] },
-      ],
+      "id-length": ["error", { min: 3, exceptions: ["_", "i", "j", "k", "id", "ok", "to", "up", "js", "fs", "os"] }],
     },
   },
   {
@@ -569,10 +560,7 @@ export default tseslint.config(
     rules: {
       // A loop counter and a discarded binding are not what this is aimed at; a variable called
       // `d` holding a customer record is. `js`, `fs`, `os` are the conventional module aliases.
-      "id-length": [
-        "error",
-        { min: 3, exceptions: ["_", "i", "j", "k", "id", "ok", "to", "up", "js", "fs", "os"] },
-      ],
+      "id-length": ["error", { min: 3, exceptions: ["_", "i", "j", "k", "id", "ok", "to", "up", "js", "fs", "os"] }],
     },
   },
   {
@@ -594,13 +582,8 @@ Entry points only where the file exists — knip prints a hint for every pattern
 ```json
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
-  "entry": [
-    "src/index.ts",
-    "test/**/*.{ts,tsx,js,jsx}"
-  ],
-  "project": [
-    "src/**/*.ts"
-  ],
+  "entry": ["src/index.ts", "test/**/*.{ts,tsx,js,jsx}"],
+  "project": ["src/**/*.ts"],
   "rules": {
     "exports": "warn",
     "types": "warn",

--- a/plans/fix-generated-config-prettier-clean.md
+++ b/plans/fix-generated-config-prettier-clean.md
@@ -1,0 +1,53 @@
+# Generated files must be what Prettier would write
+
+Closes #66.
+
+## The defect
+
+Every repository that ran `bootstrap` got an `eslint.config.js` that failed the
+`prettier/prettier` rule that same file switches on:
+
+```
+eslint.config.js
+  117:21  error  Replace `⏎········"error",⏎········{·min:·3,·…·},⏎······`
+                 with `"error",·{·min:·3,·…·}`   prettier/prettier
+```
+
+`readabilityBlock` in `src/generate/eslintConfig.ts` hand-wrapped the `id-length`
+options across four lines; the `.prettierrc.json` written beside it says
+`printWidth: 160`, so Prettier wants them on one. The generator's hand-formatting
+and the Prettier config the same tool writes disagreed.
+
+Under `freeze` it is grandfathered on the first run, so every baseline starts with
+a violation the tool itself wrote. Under `tier` it is worse, because that mode is
+visible by design: the first `ever-better tier` lists `eslint.config.js` as a file
+needing work, in a file whose header says not to edit it.
+
+`knip.json` was dirty the same way — `JSON.stringify(_, 2)` puts every array
+element on its own line and Prettier keeps a short array on one. That one does not
+fail the generated CI, which runs lint rather than `format:check`, but
+`format:check` is a script `bootstrap` itself adds.
+
+## The fix
+
+- `id-length` options on one line.
+- `renderKnipConfig` collapses arrays that fit, the way Prettier does. An array
+  that does not fit is emitted exactly as `JSON.stringify` wrote it, which is also
+  what Prettier does with it.
+
+## The test, which is the point
+
+`test/test_generatedFormatting.ts` runs Prettier over **every** sample the docs
+page renders, at the print width `bootstrap` writes, and asserts the output is
+already formatted. Nothing did that before: `test_render.ts` asserts on content
+and never on formatting, which is why a four-line block nobody had read as
+Prettier reads it shipped to every user.
+
+`.gitattributes` is exempt — Prettier has no parser for it — and the exemption is
+asserted as a list, so a new unformattable sample cannot join it silently.
+
+## Verification
+
+`bootstrap` into a fresh fixture with real ESLint, then run the repository's own
+`eslint .` and `prettier --check .`. Both clean. Before the fix, `eslint .`
+reported the error above.

--- a/src/bootstrapPlan.ts
+++ b/src/bootstrapPlan.ts
@@ -33,7 +33,8 @@ export type BootstrapPlanOptions = {
 const DEFAULT_TEST_GLOB = "test/**";
 
 /** The only Prettier setting worth writing: version 3 already defaults `trailingComma` to `"all"`. */
-const DEFAULT_PRINT_WIDTH = 160;
+/** Also what `renderKnipConfig` formats to, so the generated JSON is what Prettier would write. */
+export const DEFAULT_PRINT_WIDTH = 160;
 
 const installed = (packageJson: PackageJson | null): Set<string> =>
   new Set([...Object.keys(packageJson?.dependencies ?? {}), ...Object.keys(packageJson?.devDependencies ?? {})]);

--- a/src/generate/eslintConfig.ts
+++ b/src/generate/eslintConfig.ts
@@ -171,10 +171,7 @@ const readabilityBlock = (): string[] => [
   "    rules: {",
   "      // A loop counter and a discarded binding are not what this is aimed at; a variable called",
   "      // `d` holding a customer record is. `js`, `fs`, `os` are the conventional module aliases.",
-  '      "id-length": [',
-  '        "error",',
-  '        { min: 3, exceptions: ["_", "i", "j", "k", "id", "ok", "to", "up", "js", "fs", "os"] },',
-  "      ],",
+  '      "id-length": ["error", { min: 3, exceptions: ["_", "i", "j", "k", "id", "ok", "to", "up", "js", "fs", "os"] }],',
   "    },",
   "  },",
 ];

--- a/src/generate/knipConfig.ts
+++ b/src/generate/knipConfig.ts
@@ -1,5 +1,8 @@
 import type { PackageJson, SourceFile } from "../types.ts";
 
+/** What `bootstrap` writes into `.prettierrc.json`, and so what this output has to fit. */
+const PRINT_WIDTH = 160;
+
 const SOURCE_DIRS = ["src", "server", "lib", "app", "common"];
 const TEST_DIRS = ["test", "tests", "__tests__", "spec"];
 const ENTRY_NAMES = ["index", "main", "cli"];
@@ -39,6 +42,45 @@ const projectPatterns = (sourceFiles: readonly SourceFile[]): string[] => {
   return (dirs.length > 0 ? dirs : ["src"]).map((dir) => `${dir}/**/*.${suffix}`);
 };
 
+const OPENS_ARRAY = ": [";
+
+const isCloser = (line: string): boolean => line.trim() === "]" || line.trim() === "],";
+
+const entryOf = (line: string): string => line.trim().replace(/,$/, "");
+
+/**
+ * `JSON.stringify(_, 2)` puts every array element on its own line; Prettier keeps an array on one
+ * line when it fits. The file this generates is checked by the `format:check` script `bootstrap`
+ * itself adds, so the two have to agree — a tool whose own output fails its own scripts is not one
+ * anybody keeps running.
+ *
+ * An array that does not fit is emitted EXACTLY as it arrived, not rebuilt from its parts: the
+ * first version of this reconstructed those lines and prefixed every element with the field name.
+ * Prettier leaves a too-long array one element per line, which is what `JSON.stringify` already
+ * wrote.
+ */
+export const collapseShortArrays = (json: string, width: number): string =>
+  json
+    .split("\n")
+    .reduce<{ out: string[]; buffered: string[] | null }>(
+      (acc, line) => {
+        const buffered = acc.buffered;
+        if (buffered === null) {
+          if (!line.endsWith(OPENS_ARRAY)) return { ...acc, out: [...acc.out, line] };
+          return { out: acc.out, buffered: [line] };
+        }
+        const collected = [...buffered, line];
+        if (!isCloser(line)) return { ...acc, buffered: collected };
+
+        const opener = buffered[0] ?? "";
+        const entries = buffered.slice(1).map(entryOf);
+        const one = `${opener.slice(0, -1)}[${entries.join(", ")}]${line.trim().endsWith(",") ? "," : ""}`;
+        return { out: [...acc.out, ...(one.length <= width ? [one] : collected)], buffered: null };
+      },
+      { out: [], buffered: null },
+    )
+    .out.join("\n");
+
 /**
  * Every rule is `warn`, which is what keeps the exit code at zero. knip reports the whole
  * inventory and has no base-branch diffing, so it can never say what THIS pull request orphaned —
@@ -64,5 +106,5 @@ export const renderKnipConfig = (packageJson: PackageJson | null, sourceFiles: r
       binaries: "warn",
     },
   };
-  return `${JSON.stringify(config, null, 2)}\n`;
+  return `${collapseShortArrays(JSON.stringify(config, null, 2), PRINT_WIDTH)}\n`;
 };

--- a/test/test_generatedFormatting.ts
+++ b/test/test_generatedFormatting.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import prettier from "prettier";
+import { DEFAULT_PRINT_WIDTH } from "../src/bootstrapPlan.ts";
+import { collapseShortArrays } from "../src/generate/knipConfig.ts";
+import { CONFIG_SAMPLES, WORKFLOW_SAMPLES, type Sample } from "../src/generate/samples.ts";
+
+const PARSERS: Record<string, string> = { js: "babel", json: "json", yaml: "yaml" };
+
+const samples: Sample[] = [...CONFIG_SAMPLES, ...WORKFLOW_SAMPLES];
+
+const formattable = samples.filter((sample) => PARSERS[sample.language] !== undefined);
+
+/**
+ * Every file `bootstrap` generates, checked against the Prettier config `bootstrap` generates
+ * beside it. The generated `eslint.config.js` used to fail its own `prettier/prettier` rule (#66):
+ * the `id-length` options were hand-wrapped across four lines and Prettier wanted them on one, so
+ * every repository that ran `bootstrap` started with a violation the tool itself had written — in
+ * a file whose header says not to edit it. Nothing here read the generated output the way Prettier
+ * does, so nothing caught it.
+ */
+describe("generated files are Prettier-clean", () => {
+  formattable.forEach((sample) => {
+    it(`${sample.title}`, async () => {
+      const formatted = await prettier.format(sample.contents, { parser: PARSERS[sample.language] ?? "", printWidth: DEFAULT_PRINT_WIDTH });
+      assert.equal(sample.contents, formatted, `${sample.title} is not what Prettier would write`);
+    });
+  });
+
+  /** A sample in a language Prettier cannot parse is exempt, so the exempt list has to be visible. */
+  it("formats everything except the files Prettier has no parser for", () => {
+    assert.deepEqual(
+      samples.filter((sample) => PARSERS[sample.language] === undefined).map((sample) => sample.title),
+      [".gitattributes"],
+    );
+    assert.ok(formattable.length > 10, "the sample set shrank; this test is only as wide as it is");
+  });
+});
+
+describe("collapseShortArrays", () => {
+  const json = (value: unknown): string => JSON.stringify(value, null, 2);
+
+  it("puts an array that fits on one line, the way Prettier does", () => {
+    assert.match(collapseShortArrays(json({ entry: ["a.ts", "b.ts"] }), 160), /"entry": \["a\.ts", "b\.ts"\]/);
+  });
+
+  /**
+   * Not rebuilt from its parts — emitted exactly as it arrived. The first version reconstructed
+   * these lines and prefixed every element with the field name, which corrupts the file for any
+   * repository with enough entry points to wrap.
+   */
+  it("leaves an array that does not fit exactly as it was", () => {
+    const long = json({ entry: Array.from({ length: 12 }, (_, at) => `src/some/quite/long/path/number-${at}/index.ts`) });
+    assert.equal(collapseShortArrays(long, 160), long);
+  });
+
+  it("keeps the trailing comma when the field is not the last one", () => {
+    const collapsed = collapseShortArrays(json({ entry: ["a.ts"], project: ["b.ts"] }), 160);
+    assert.match(collapsed, /"entry": \["a\.ts"\],\n/);
+    assert.match(collapsed, /"project": \["b\.ts"\]\n/);
+  });
+
+  it("leaves a document with no arrays alone", () => {
+    const plain = json({ rules: { exports: "warn" } });
+    assert.equal(collapseShortArrays(plain, 160), plain);
+  });
+});


### PR DESCRIPTION
## Summary

`bootstrap` generated an `eslint.config.js` that failed the `prettier/prettier` rule that same file switches on:

```
eslint.config.js
  117:21  error  Replace `⏎········"error",⏎········{·min:·3,·…·},⏎······` with
                 `"error",·{·min:·3,·…·}`   prettier/prettier
```

The `id-length` options were hand-wrapped across four lines; the `.prettierrc.json` written beside them says `printWidth: 160`. The generator's formatting and the Prettier config the same tool writes disagreed.

Under `freeze` it is grandfathered on the first run, so **every baseline started with a violation the tool itself wrote**. Under `tier` (#58, just merged) it is worse, because that mode is visible by design: the first `ever-better tier` listed `eslint.config.js` as a file needing work — a file whose header says not to edit it.

`knip.json` was dirty the same way: `JSON.stringify(_, 2)` puts every array element on its own line and Prettier keeps a short array on one. That one does not fail the generated CI, which runs `lint` rather than `format:check` — but `format:check` is a script `bootstrap` itself adds.

Closes #66.

## Items to Confirm / Review

1. **The test is the deliverable, not the two-line fix.** `test/test_generatedFormatting.ts` runs Prettier over every sample the docs page renders, at the print width `bootstrap` writes, and asserts it is already formatted. `test_render.ts` asserts on content and never on formatting, which is exactly how a four-line block nobody had read the way Prettier reads it shipped to every user.
2. **`collapseShortArrays` is a small formatting decision this repo now owns.** It matches Prettier's rule for arrays of scalars — inline if it fits, otherwise one per line. An array that does not fit is emitted **exactly as it arrived** rather than rebuilt: the first version reconstructed those lines and prefixed every element with the field name, which corrupts the file for any repository with enough entry points to wrap. That was caught by the test written for it, not by reading. If Prettier ever changes that rule, the samples test goes red and says so.
3. **`.gitattributes` is exempt** because Prettier has no parser for it. The exemption is asserted as a list, so a new unformattable sample cannot join it silently.
4. **A user's own files are still not reformatted.** `bootstrap` edits `tsconfig.json` surgically and preserves whatever formatting is there — verified that a repo with a compact one-line `tsconfig.json` keeps it, at the cost of `prettier --check` flagging that file. Reformatting a file the tool does not own would be the worse behaviour.

## User Prompt

- 66ってなに？ → はい

(after the #58 tier work merged, on the follow-up this PR closes)

## Verification

Against the ground truth rather than the generators: `bootstrap` into a fresh fixture with real ESLint, then run the repository's **own** `eslint .` and `prettier --check .`.

| | before | after |
| --- | --- | --- |
| `eslint .` on a freshly bootstrapped repo | 1 error in `eslint.config.js` | clean |
| `prettier --check .` | flags `knip.json` | clean |

Break-verified: hand-wrapping the `id-length` options again turns four sample tests red; dropping `collapseShortArrays` turns the `knip.json` one red.

`format` / `lint` / `typecheck` / `build` / `test` (461) / `knip` — exit codes checked, not piped.

**`test:e2e` was left to CI.** The machine is at load average 47 and that suite installs real packages; it exercises `bootstrap` end to end, so it is the check that matters here and I would rather it ran on an unloaded runner than be reported from a thrashing one.
