### PR TITLE
ever-better@0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ever-better",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Diagnose a repository, install the quality tooling it is missing, and pin a baseline that can only get better.",
   "keywords": [
     "eslint",


### PR DESCRIPTION
## Summary

Version bump for the 0.5.0 release. `main` is a protected branch, so the release commit lands through a PR — the same way [#45](https://github.com/isamu/ever-better/pull/45) landed 0.4.1.

The `0.5.0` tag already points at the commit in this PR (`cbdabf4`); merging makes it an ancestor of `main`, which is what the published tarball has to correspond to.

## Items to Confirm / Review

- **Minor, not patch.** Three new commands since 0.4.1 — `tier` (#65), `secrets` (#53), `report` (#52) — plus behaviour changes to what `bootstrap` generates (#57, #67).
- Nothing but `package.json` changes here.

## User Prompt

- publish
- 4はこっちで手動で行うのでそれいがいはすすめて

## Verification

`install --frozen-lockfile` / `typecheck` / `lint` / `build` / `test` (461) green on this commit. Publish tarball inspected: zero runtime dependencies, `dist` + `formatters` + READMEs + LICENSE, no `file:` deps, no debug statements in shipped source.